### PR TITLE
Ensure dependencies are compatible with the project's JDK target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,34 @@
         <artifactId>maven-site-plugin</artifactId>
         <version>3.3</version>
       </plugin>
+	<plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-enforcer-plugin</artifactId>
+		<version>1.4.1</version>
+		<executions>
+			<execution>
+				<id>enforce-bytecode-version</id>
+				<goals>
+					<goal>enforce</goal>
+				</goals>
+				<configuration>
+					<rules>
+						<enforceBytecodeVersion>
+							<maxJdkVersion>1.7</maxJdkVersion>
+						</enforceBytecodeVersion>
+					</rules>
+					<fail>true</fail>
+				</configuration>
+			</execution>
+		</executions>
+		<dependencies>
+			<dependency>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>extra-enforcer-rules</artifactId>
+				<version>1.3</version>
+			</dependency>
+		</dependencies>
+	</plugin>
     </plugins>
   </build>
   <reporting>


### PR DESCRIPTION
This adds a maven-enforce rule to check that the bytecode of any dependencies is not greater than the JDK target of the code (currently has to be manually set in the enforceBytecodeVersion child). 

See also:
  http://www.mojohaus.org/extra-enforcer-rules/enforceBytecodeVersion.html
  https://stackoverflow.com/questions/26559830/required-java-version-of-maven-dependency
