### PR TITLE
Enhanced stereochemistry support

### DIFF
--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/Atom.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/Atom.java
@@ -628,11 +628,19 @@ class Atom {
 		return b;
 	}
 
+	/**
+	 * Set the stereo group, ignored if the atom does not have any parity info.
+	 * @param stroGrp the stereo group.
+	 */
 	public void setStereoGroup(StereoGroup stroGrp) {
 		if (atomParity != null)
 			atomParity.setStereoGroup(stroGrp);
 	}
 
+	/**
+	 * Access the stereo group on the atom parity info.
+	 * @return the stereo group
+	 */
 	public StereoGroup getStereoGroup() {
 		return atomParity != null ? atomParity.getStereoGroup() : StereoGroup.Unk;
 	}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/Atom.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/Atom.java
@@ -627,4 +627,13 @@ class Atom {
 		}
 		return b;
 	}
+
+	public void setStereoGroup(StereoGroup stroGrp) {
+		if (atomParity != null)
+			atomParity.setStereoGroup(stroGrp);
+	}
+
+	public StereoGroup getStereoGroup() {
+		return atomParity != null ? atomParity.getStereoGroup() : StereoGroup.Unk;
+	}
 }

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/AtomParity.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/AtomParity.java
@@ -16,6 +16,7 @@ class AtomParity {
 	static final Atom deoxyHydrogen = new Atom(ChemEl.H);
 	private Atom[] atomRefs4;
 	private int parity;
+	private StereoGroup stereoGroup = StereoGroup.Unk;
 	
 	/**
 	 * Create an atomParity from an array of 4 atoms and the parity of the chiral determinant
@@ -41,5 +42,13 @@ class AtomParity {
 	}
 	void setParity(int parity) {
 		this.parity = parity;
+	}
+
+	public void setStereoGroup(StereoGroup stroGrp) {
+		this.stereoGroup = stroGrp;
+	}
+
+	public StereoGroup getStereoGroup() {
+		return this.stereoGroup;
 	}
 }

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/CMLWriter.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/CMLWriter.java
@@ -135,7 +135,7 @@ class CMLWriter {
 			}
 		}
 		AtomParity atomParity = atom.getAtomParity();
-		if(atomParity != null){
+		if(atomParity != null && atomParity.getStereoGroup() != StereoGroup.Rac){
 			writeAtomParity(atomParity);
 		}
 		for(String locant : atom.getLocants()) {

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentGenerator.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentGenerator.java
@@ -877,11 +877,11 @@ class ComponentGenerator {
 	}
 
 	private void processStereochemistryBracket(Element stereoChemistryElement) throws ComponentGenerationException {
-	  StereoGroup group = null;
-		String txt = stereoChemistryElement.getValue();
-		if (StringTools.startsWithCaseInsensitive(txt, "rel-")){
+		StereoGroup group = null;
+		String      txt   = stereoChemistryElement.getValue();
+		if (StringTools.startsWithCaseInsensitive(txt, "rel-")) {
 			group = StereoGroup.Rel;
-			txt = txt.substring(4);
+			txt   = txt.substring(4);
 		}
 		txt = StringTools.removeDashIfPresent(txt);
 		Matcher racemicMacher = matchRacemic.matcher(txt);
@@ -894,78 +894,75 @@ class ComponentGenerator {
 
 		if (txt.length() > 0) {//if txt is just "rel- or rac-" then it will be length 0 at this point
 			List<String> stereoChemistryDescriptors = splitStereoBracketIntoDescriptors(txt);
-			boolean exclusiveStereoTerm = false;
-			if (stereoChemistryDescriptors.size() == 1){
+			boolean      exclusiveStereoTerm        = false;
+			if (stereoChemistryDescriptors.size() == 1) {
 				String stereoChemistryDescriptor = stereoChemistryDescriptors.get(0);
-				if (stereoChemistryDescriptor.equalsIgnoreCase("rel")){
-					group = StereoGroup.Rel;
+				if (stereoChemistryDescriptor.equalsIgnoreCase("rel")) {
+					group               = StereoGroup.Rel;
 					exclusiveStereoTerm = true;
 				}
 				if (matchRacemic.matcher(stereoChemistryDescriptor).matches()) {
-					group = StereoGroup.Rac;
+					group               = StereoGroup.Rac;
 					exclusiveStereoTerm = true;
 				}
 			}
 			if (!exclusiveStereoTerm) {
-			    for (String stereoChemistryDescriptor : stereoChemistryDescriptors) {
-			        Matcher m = matchStereochemistry.matcher(stereoChemistryDescriptor);
-			        if (m.matches()){
-		                Element stereoChemEl = new TokenEl(STEREOCHEMISTRY_EL, stereoChemistryDescriptor);
-		                String locantVal = m.group(1);
-		                if (locantVal.length() > 0){
-		                    stereoChemEl.addAttribute(new Attribute(LOCANT_ATR, fixLocantCapitalisation(StringTools.removeDashIfPresent(locantVal))));
-		                }
-                    OpsinTools.insertBefore(stereoChemistryElement, stereoChemEl);
-		                if (matchRS.matcher(m.group(2)).matches()) {
-                        stereoChemEl.addAttribute(new Attribute(TYPE_ATR, R_OR_S_TYPE_VAL));
-                        String symbol = m.group(2).toUpperCase(Locale.ROOT).replaceAll("/", "");
-                        StereoGroup groupLocal = group;
-                        if (group == StereoGroup.Rac && symbol.length() == 1) {
-                          symbol = (symbol.equals("R")) ? "RS" : "SR";
-                        } else if (symbol.equals("RS") || symbol.equals("SR")) {
-                          groupLocal = StereoGroup.Rac;
-                        } else if (symbol.length() == 2 && symbol.charAt(1) == '*') {
-                          symbol     = symbol.substring(0, 1); // R* => R, R* => S
-                          groupLocal = StereoGroup.Rel;
-                        }
-                        stereoChemEl.addAttribute(new Attribute(VALUE_ATR, symbol));
-                        if (groupLocal == null)
-                          groupLocal = StereoGroup.Abs;
-                        stereoChemEl.addAttribute(new Attribute(STEREOGROUP_ATR, groupLocal.name()));
-		                } else if (matchEZ.matcher(m.group(2)).matches()) {
-		                    stereoChemEl.addAttribute(new Attribute(TYPE_ATR, E_OR_Z_TYPE_VAL));
-		                    String symbol = m.group(2).toUpperCase(Locale.ROOT);
-		                    stereoChemEl.addAttribute(new Attribute(VALUE_ATR,symbol));
-		                } else if (matchAlphaBetaStereochem.matcher(m.group(2)).matches()){
-		                	stereoChemEl.addAttribute(new Attribute(TYPE_ATR, ALPHA_OR_BETA_TYPE_VAL));
-		                	if (Character.toLowerCase(m.group(2).charAt(0)) == 'a'){
-		                    	stereoChemEl.addAttribute(new Attribute(VALUE_ATR, "alpha"));
-		                	}
-		                	else if (Character.toLowerCase(m.group(2).charAt(0)) == 'b'){
-		                    	stereoChemEl.addAttribute(new Attribute(VALUE_ATR, "beta"));
-		                	}
-		                 	else if (Character.toLowerCase(m.group(2).charAt(0)) == 'x'){
-		                    	stereoChemEl.addAttribute(new Attribute(VALUE_ATR, "xi"));
-		                	}
-		                	else{
-		                		throw new ComponentGenerationException("Malformed alpha/beta stereochemistry element: " + stereoChemistryElement.getValue());
-		                	}
-		        	 	} else if (matchCisTrans.matcher(m.group(2)).matches()) {
-		                    stereoChemEl.addAttribute(new Attribute(TYPE_ATR, CISORTRANS_TYPE_VAL));
-		                    stereoChemEl.addAttribute(new Attribute(VALUE_ATR, m.group(2).toLowerCase(Locale.ROOT)));
-		        	 	} else if (matchEndoExoSynAnti.matcher(m.group(2)).matches()) {
-		                    stereoChemEl.addAttribute(new Attribute(TYPE_ATR, ENDO_EXO_SYN_ANTI_TYPE_VAL));
-		                    stereoChemEl.addAttribute(new Attribute(VALUE_ATR, m.group(2).toLowerCase(Locale.ROOT)));
-		        	 	} else if (matchAxialStereo.matcher(m.group(2)).matches()) {
-		                    stereoChemEl.addAttribute(new Attribute(TYPE_ATR, AXIAL_TYPE_VAL));
-		                    stereoChemEl.addAttribute(new Attribute(VALUE_ATR, m.group(2)));
-		        	 	} else {
-		                    throw new ComponentGenerationException("Malformed stereochemistry element: " + stereoChemistryElement.getValue());
-		                }
-			        } else {
-			            throw new ComponentGenerationException("Malformed stereochemistry element: " + stereoChemistryElement.getValue());
-			        }
-			    }
+				for (String stereoChemistryDescriptor : stereoChemistryDescriptors) {
+					Matcher m = matchStereochemistry.matcher(stereoChemistryDescriptor);
+					if (m.matches()) {
+						Element stereoChemEl = new TokenEl(STEREOCHEMISTRY_EL, stereoChemistryDescriptor);
+						String  locantVal    = m.group(1);
+						if (locantVal.length() > 0) {
+							stereoChemEl.addAttribute(new Attribute(LOCANT_ATR, fixLocantCapitalisation(StringTools.removeDashIfPresent(locantVal))));
+						}
+						OpsinTools.insertBefore(stereoChemistryElement, stereoChemEl);
+						if (matchRS.matcher(m.group(2)).matches()) {
+							stereoChemEl.addAttribute(new Attribute(TYPE_ATR, R_OR_S_TYPE_VAL));
+							String      symbol     = m.group(2).toUpperCase(Locale.ROOT).replaceAll("/", "");
+							StereoGroup groupLocal = group;
+							if (group == StereoGroup.Rac && symbol.length() == 1) {
+								symbol = (symbol.equals("R")) ? "RS" : "SR";
+							} else if (symbol.equals("RS") || symbol.equals("SR")) {
+								groupLocal = StereoGroup.Rac;
+							} else if (symbol.length() == 2 && symbol.charAt(1) == '*') {
+								symbol     = symbol.substring(0, 1); // R* => R, R* => S
+								groupLocal = StereoGroup.Rel;
+							}
+							stereoChemEl.addAttribute(new Attribute(VALUE_ATR, symbol));
+							if (groupLocal == null)
+								groupLocal = StereoGroup.Abs;
+							stereoChemEl.addAttribute(new Attribute(STEREOGROUP_ATR, groupLocal.name()));
+						} else if (matchEZ.matcher(m.group(2)).matches()) {
+							stereoChemEl.addAttribute(new Attribute(TYPE_ATR, E_OR_Z_TYPE_VAL));
+							String symbol = m.group(2).toUpperCase(Locale.ROOT);
+							stereoChemEl.addAttribute(new Attribute(VALUE_ATR, symbol));
+						} else if (matchAlphaBetaStereochem.matcher(m.group(2)).matches()) {
+							stereoChemEl.addAttribute(new Attribute(TYPE_ATR, ALPHA_OR_BETA_TYPE_VAL));
+							if (Character.toLowerCase(m.group(2).charAt(0)) == 'a') {
+								stereoChemEl.addAttribute(new Attribute(VALUE_ATR, "alpha"));
+							} else if (Character.toLowerCase(m.group(2).charAt(0)) == 'b') {
+								stereoChemEl.addAttribute(new Attribute(VALUE_ATR, "beta"));
+							} else if (Character.toLowerCase(m.group(2).charAt(0)) == 'x') {
+								stereoChemEl.addAttribute(new Attribute(VALUE_ATR, "xi"));
+							} else {
+								throw new ComponentGenerationException("Malformed alpha/beta stereochemistry element: " + stereoChemistryElement.getValue());
+							}
+						} else if (matchCisTrans.matcher(m.group(2)).matches()) {
+							stereoChemEl.addAttribute(new Attribute(TYPE_ATR, CISORTRANS_TYPE_VAL));
+							stereoChemEl.addAttribute(new Attribute(VALUE_ATR, m.group(2).toLowerCase(Locale.ROOT)));
+						} else if (matchEndoExoSynAnti.matcher(m.group(2)).matches()) {
+							stereoChemEl.addAttribute(new Attribute(TYPE_ATR, ENDO_EXO_SYN_ANTI_TYPE_VAL));
+							stereoChemEl.addAttribute(new Attribute(VALUE_ATR, m.group(2).toLowerCase(Locale.ROOT)));
+						} else if (matchAxialStereo.matcher(m.group(2)).matches()) {
+							stereoChemEl.addAttribute(new Attribute(TYPE_ATR, AXIAL_TYPE_VAL));
+							stereoChemEl.addAttribute(new Attribute(VALUE_ATR, m.group(2)));
+						} else {
+							throw new ComponentGenerationException("Malformed stereochemistry element: " + stereoChemistryElement.getValue());
+						}
+					} else {
+						throw new ComponentGenerationException("Malformed stereochemistry element: " + stereoChemistryElement.getValue());
+					}
+				}
 			} else {
 				// Rac or Rel exclusively
 				Element stereoChemEl = new TokenEl(STEREOCHEMISTRY_EL, stereoChemistryElement.getValue());
@@ -974,7 +971,7 @@ class ComponentGenerator {
 				else
 					stereoChemEl.addAttribute(new Attribute(TYPE_ATR, REL_TYPE_VAL));
 				OpsinTools.insertBefore(stereoChemistryElement, stereoChemEl);
-      }
+			}
 		} else {
 			if (group == StereoGroup.Rac || group == StereoGroup.Rel) {
 				Element stereoChemEl = new TokenEl(STEREOCHEMISTRY_EL, stereoChemistryElement.getValue());
@@ -984,7 +981,7 @@ class ComponentGenerator {
 					stereoChemEl.addAttribute(new Attribute(TYPE_ATR, REL_TYPE_VAL));
 				OpsinTools.insertBefore(stereoChemistryElement, stereoChemEl);
 			}
-    }
+		}
 
 		stereoChemistryElement.detach();
 	}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentGenerator.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentGenerator.java
@@ -900,8 +900,7 @@ class ComponentGenerator {
 				if (stereoChemistryDescriptor.equalsIgnoreCase("rel")) {
 					group               = StereoGroup.Rel;
 					exclusiveStereoTerm = true;
-				}
-				if (matchRacemic.matcher(stereoChemistryDescriptor).matches()) {
+				} else if (matchRacemic.matcher(stereoChemistryDescriptor).matches()) {
 					group               = StereoGroup.Rac;
 					exclusiveStereoTerm = true;
 				}
@@ -922,12 +921,18 @@ class ComponentGenerator {
 							StereoGroup groupLocal = group; // needs to be local
 							if (symbol.equals("RS") || symbol.equals("SR") ||
 									symbol.equals("RANDS") || symbol.equals("SANDR")) {
-								groupLocal = StereoGroup.Rac;
+								// rel-(RS) is conflicting, interpret as relative even though a
+								// relative descriptor was used
+								if (groupLocal == null)
+									groupLocal = StereoGroup.Rac;
 								symbol     = symbol.substring(0, 1); // RS => R, SR => S
 							} else if (symbol.equals("R*") || symbol.equals("S*") ||
 												 symbol.equals("R^*") || symbol.equals("S^*") ||
 												 symbol.equals("RORS") || symbol.equals("SORR")) {
-								groupLocal = StereoGroup.Rel;
+								// rac-(R*) is conflicting, interpret as racemic even though a
+								// relative descriptor was used
+								if (groupLocal == null)
+									groupLocal = StereoGroup.Rel;
 								symbol     = symbol.substring(0, 1); // R* => R, S* => S
 							}
 							stereoChemEl.addAttribute(new Attribute(VALUE_ATR, symbol));

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentGenerator.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentGenerator.java
@@ -71,10 +71,10 @@ class ComponentGenerator {
 	private static final Pattern matchCommaOrDot =Pattern.compile("[\\.,]");
 	private static final Pattern matchAnnulene = Pattern.compile("[\\[\\(\\{]([1-9]\\d*)[\\]\\)\\}]annulen");
 	private static final String elementSymbols ="(?:He|Li|Be|B|C|N|O|F|Ne|Na|Mg|Al|Si|P|S|Cl|Ar|K|Ca|Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Ga|Ge|As|Se|Br|Kr|Rb|Sr|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|In|Sn|Sb|Te|I|Xe|Cs|Ba|La|Ce|Pr|Nd|Pm|Sm|Eu|Gd|Tb|Dy|Ho|Er|Tm|Yb|Lu|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg|Tl|Pb|Po|At|Rn|Fr|Ra|Ac|Th|Pa|U|Np|Pu|Am|Cm|Bk|Cf|Es|Fm|Md|No|Lr|Rf|Db|Sg|Bh|Hs|Mt|Ds)";
-	private static final Pattern matchStereochemistry = Pattern.compile("(.*?)(SR|R/?S|r/?s|[Rr][*]|[Ss][*]|[Ee][Zz]|[RSEZrsezabx]|[cC][iI][sS]|[tT][rR][aA][nN][sS]|[aA][lL][pP][hH][aA]|[bB][eE][tT][aA]|[xX][iI]|[eE][xX][oO]|[eE][nN][dD][oO]|[sS][yY][nN]|[aA][nN][tT][iI]|M|P|Ra|Sa|Sp|Rp)");
+	private static final Pattern matchStereochemistry = Pattern.compile("(.*?)(SR|R/?S|r/?s|[Rr][*]|[Ss][*]|[Ee][Zz]|[RSEZrsezabx]|[cC][iI][sS]|[tT][rR][aA][nN][sS]|[aA][lL][pP][hH][aA]|[bB][eE][tT][aA]|[xX][iI]|[eE][xX][oO]|[eE][nN][dD][oO]|[sS][yY][nN]|[aA][nN][tT][iI]|M|P|Ra|Sa|Sp|Rp|R(?:[Oo][Rr]|[Aa][Nn][Dd])S|S(?:[Oo][Rr]|[Aa][Nn][Dd])R)");
 	private static final Pattern matchStar = Pattern.compile("\\^?\\*");
 	private static final Pattern matchRacemic = Pattern.compile("rac(\\.|em(\\.|ic)?)?-?", Pattern.CASE_INSENSITIVE);
-	private static final Pattern matchRS = Pattern.compile("[Rr]/?[*Ss]?|[Ss][*Rr]?");
+	private static final Pattern matchRS = Pattern.compile("[Rr]/?[*Ss]?|[Ss][*Rr]?|R(?:[Oo][Rr]|[Aa][Nn][Dd])S|S(?:[Oo][Rr]|[Aa][Nn][Dd])R");
 	private static final Pattern matchEZ = Pattern.compile("[EZez]|[Ee][Zz]");
 	private static final Pattern matchAlphaBetaStereochem = Pattern.compile("a|b|x|[aA][lL][pP][hH][aA]|[bB][eE][tT][aA]|[xX][iI]");
 	private static final Pattern matchCisTrans = Pattern.compile("[cC][iI][sS]|[tT][rR][aA][nN][sS]");
@@ -919,11 +919,13 @@ class ComponentGenerator {
 						if (matchRS.matcher(m.group(2)).matches()) {
 							stereoChemEl.addAttribute(new Attribute(TYPE_ATR, R_OR_S_TYPE_VAL));
 							String      symbol     = m.group(2).toUpperCase(Locale.ROOT).replaceAll("/", "");
-							StereoGroup groupLocal = group;
-							if (symbol.equals("RS") || symbol.equals("SR")) {
+							StereoGroup groupLocal = group; // needs to be local
+							if (symbol.equals("RS") || symbol.equals("SR") ||
+									symbol.equals("RANDS") || symbol.equals("SANDR")) {
 								groupLocal = StereoGroup.Rac;
 								symbol     = symbol.substring(0, 1); // RS => R, SR => S
-							} else if (symbol.length() == 2 && symbol.charAt(1) == '*') {
+							} else if (symbol.equals("R*") || symbol.equals("S*") ||
+												 symbol.equals("RORS") || symbol.equals("SORR")) {
 								groupLocal = StereoGroup.Rel;
 								symbol     = symbol.substring(0, 1); // R* => R, S* => S
 							}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentGenerator.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentGenerator.java
@@ -920,13 +920,12 @@ class ComponentGenerator {
 							stereoChemEl.addAttribute(new Attribute(TYPE_ATR, R_OR_S_TYPE_VAL));
 							String      symbol     = m.group(2).toUpperCase(Locale.ROOT).replaceAll("/", "");
 							StereoGroup groupLocal = group;
-							if (group == StereoGroup.Rac && symbol.length() == 1) {
-								symbol = (symbol.equals("R")) ? "RS" : "SR";
-							} else if (symbol.equals("RS") || symbol.equals("SR")) {
+							if (symbol.equals("RS") || symbol.equals("SR")) {
 								groupLocal = StereoGroup.Rac;
+								symbol     = symbol.substring(0, 1); // RS => R, SR => S
 							} else if (symbol.length() == 2 && symbol.charAt(1) == '*') {
-								symbol     = symbol.substring(0, 1); // R* => R, R* => S
 								groupLocal = StereoGroup.Rel;
+								symbol     = symbol.substring(0, 1); // R* => R, S* => S
 							}
 							stereoChemEl.addAttribute(new Attribute(VALUE_ATR, symbol));
 							if (groupLocal == null)

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentGenerator.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentGenerator.java
@@ -71,10 +71,10 @@ class ComponentGenerator {
 	private static final Pattern matchCommaOrDot =Pattern.compile("[\\.,]");
 	private static final Pattern matchAnnulene = Pattern.compile("[\\[\\(\\{]([1-9]\\d*)[\\]\\)\\}]annulen");
 	private static final String elementSymbols ="(?:He|Li|Be|B|C|N|O|F|Ne|Na|Mg|Al|Si|P|S|Cl|Ar|K|Ca|Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Ga|Ge|As|Se|Br|Kr|Rb|Sr|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|In|Sn|Sb|Te|I|Xe|Cs|Ba|La|Ce|Pr|Nd|Pm|Sm|Eu|Gd|Tb|Dy|Ho|Er|Tm|Yb|Lu|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg|Tl|Pb|Po|At|Rn|Fr|Ra|Ac|Th|Pa|U|Np|Pu|Am|Cm|Bk|Cf|Es|Fm|Md|No|Lr|Rf|Db|Sg|Bh|Hs|Mt|Ds)";
-	private static final Pattern matchStereochemistry = Pattern.compile("(.*?)(SR|R/?S|r/?s|[Rr][*]|[Ss][*]|[Ee][Zz]|[RSEZrsezabx]|[cC][iI][sS]|[tT][rR][aA][nN][sS]|[aA][lL][pP][hH][aA]|[bB][eE][tT][aA]|[xX][iI]|[eE][xX][oO]|[eE][nN][dD][oO]|[sS][yY][nN]|[aA][nN][tT][iI]|M|P|Ra|Sa|Sp|Rp|R(?:[Oo][Rr]|[Aa][Nn][Dd])S|S(?:[Oo][Rr]|[Aa][Nn][Dd])R)");
+	private static final Pattern matchStereochemistry = Pattern.compile("(.*?)(SR|R/?S|r/?s|[Rr]\\^?[*]|[Ss]\\^?[*]|[Ee][Zz]|[RSEZrsezabx]|[cC][iI][sS]|[tT][rR][aA][nN][sS]|[aA][lL][pP][hH][aA]|[bB][eE][tT][aA]|[xX][iI]|[eE][xX][oO]|[eE][nN][dD][oO]|[sS][yY][nN]|[aA][nN][tT][iI]|M|P|Ra|Sa|Sp|Rp|R(?:[Oo][Rr]|[Aa][Nn][Dd])S|S(?:[Oo][Rr]|[Aa][Nn][Dd])R)");
 	private static final Pattern matchStar = Pattern.compile("\\^?\\*");
 	private static final Pattern matchRacemic = Pattern.compile("rac(\\.|em(\\.|ic)?)?-?", Pattern.CASE_INSENSITIVE);
-	private static final Pattern matchRS = Pattern.compile("[Rr]/?[*Ss]?|[Ss][*Rr]?|R(?:[Oo][Rr]|[Aa][Nn][Dd])S|S(?:[Oo][Rr]|[Aa][Nn][Dd])R");
+	private static final Pattern matchRS = Pattern.compile("[Rr]/?\\^?[*Ss]?|[Ss]\\^?[*Rr]?|R(?:[Oo][Rr]|[Aa][Nn][Dd])S|S(?:[Oo][Rr]|[Aa][Nn][Dd])R");
 	private static final Pattern matchEZ = Pattern.compile("[EZez]|[Ee][Zz]");
 	private static final Pattern matchAlphaBetaStereochem = Pattern.compile("a|b|x|[aA][lL][pP][hH][aA]|[bB][eE][tT][aA]|[xX][iI]");
 	private static final Pattern matchCisTrans = Pattern.compile("[cC][iI][sS]|[tT][rR][aA][nN][sS]");
@@ -925,6 +925,7 @@ class ComponentGenerator {
 								groupLocal = StereoGroup.Rac;
 								symbol     = symbol.substring(0, 1); // RS => R, SR => S
 							} else if (symbol.equals("R*") || symbol.equals("S*") ||
+												 symbol.equals("R^*") || symbol.equals("S^*") ||
 												 symbol.equals("RORS") || symbol.equals("SORR")) {
 								groupLocal = StereoGroup.Rel;
 								symbol     = symbol.substring(0, 1); // R* => R, S* => S

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/FragmentManager.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/FragmentManager.java
@@ -406,6 +406,7 @@ class FragmentManager {
 					}
 				}
 				AtomParity newAtomParity =new AtomParity(newAtomRefs4, atom.getAtomParity().getParity());
+				newAtomParity.setStereoGroup(atom.getAtomParity().getStereoGroup());
 				oldToNewAtomMap.get(atom).setAtomParity(newAtomParity);
 			}
 			Set<Atom> oldAmbiguousElementAssignmentAtoms = atom.getProperty(Atom.AMBIGUOUS_ELEMENT_ASSIGNMENT);

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StereoGroup.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StereoGroup.java
@@ -1,0 +1,33 @@
+package uk.ac.cam.ch.wwmm.opsin;
+
+/**
+ * Indicate if a stereo-center belongs to a certain stereo group type. The group
+ * can be specified on the {@link AtomParity}. For formats that support enhanced
+ * stereo (currently only CXSMILES) you would normally also have a group number
+ * (e.g. Rac1/&1, Rac2/&2, Rac3/&3, etc) however there is currently no way to
+ * specify this separation in IUPAC. An extension may be to indicate grouping
+ * with parenthesis "(1RS)-,(3RS)-" "((1RS),(3RS))-". However the most common
+ * cases of mixed stereo groups are likely to be where part of the structure is
+ * known (absolute) and part is racemic/relative which can be specified like
+ * this "(1RS,3R)-". The most common cases are all absolute, all racemic (AND
+ * enantiomer), all relative (OR enantiomer).
+ */
+public enum StereoGroup {
+	/**
+	 * Absolute stereochemistry, the configuration of the stereo center is known.
+	 */
+  Abs,
+	/**
+	 * Racemic stereochemistry, the molecule is a mixture of the stereo center.
+	 */
+  Rac,
+	/**
+	 * Relative stereochemistry, the configuration of a stereo center is unknown
+	 * but may be known relative to another configuration.
+	 */
+  Rel,
+	/**
+	 * Fallback sentinel value to ensure non-null.
+	 */
+  Unk
+}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StereoGroup.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StereoGroup.java
@@ -4,13 +4,13 @@ package uk.ac.cam.ch.wwmm.opsin;
  * Indicate if a stereo-center belongs to a certain stereo group type. The group
  * can be specified on the {@link AtomParity}. For formats that support enhanced
  * stereo (currently only CXSMILES) you would normally also have a group number
- * (e.g. Rac1/&1, Rac2/&2, Rac3/&3, etc) however there is currently no way to
- * specify this separation in IUPAC. An extension may be to indicate grouping
- * with parenthesis "(1RS)-,(3RS)-" "((1RS),(3RS))-". However the most common
- * cases of mixed stereo groups are likely to be where part of the structure is
- * known (absolute) and part is racemic/relative which can be specified like
- * this "(1RS,3R)-". The most common cases are all absolute, all racemic (AND
- * enantiomer), all relative (OR enantiomer).
+ * (e.g. Rac1/&amp;1, Rac2/&amp;2, Rac3/&amp;3, etc) however there is currently
+ * no way to specify this separation in IUPAC. An extension may be to indicate
+ * grouping with parenthesis "(1RS)-,(3RS)-" "((1RS),(3RS))-". However the most
+ * common cases of mixed stereo groups are likely to be where part of the
+ * structure is known (absolute) and part is racemic/relative which can be
+ * specified like this "(1RS,3R)-". The most common cases are all absolute, all
+ * racemic (AND enantiomer), all relative (OR enantiomer).
  */
 public enum StereoGroup {
 	/**

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryHandler.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryHandler.java
@@ -226,20 +226,34 @@ class StereochemistryHandler {
 		for (int i = adjacentGroupEls.size()-1; i >=0; i--) {
 			possibleFragments.add(adjacentGroupEls.get(i).getFrag());
 		}
+
+		// first for allready defined stereochemistry
+		List<Atom> definedStereo = new ArrayList<>();
 		for (Fragment fragment : possibleFragments) {
 			List<Atom> atomList = fragment.getAtomList();
 			for (Atom potentialStereoAtom : atomList) {
+				if (potentialStereoAtom.getAtomParity() != null)
+					definedStereo.add(potentialStereoAtom);
+			}
+		}
 
-				if (potentialStereoAtom.getAtomParity() != null) {
-					potentialStereoAtom.setStereoGroup(group);
-				}
-
-				if (notExplicitlyDefinedStereoCentreMap.containsKey(potentialStereoAtom)){
-					applyStereoChemistryToStereoCentre(potentialStereoAtom,
-																						 notExplicitlyDefinedStereoCentreMap.get(potentialStereoAtom),
-																						 "R");
-					potentialStereoAtom.setStereoGroup(group);
-					notExplicitlyDefinedStereoCentreMap.remove(potentialStereoAtom);
+		// if some were defined we assign them to be relative/racemic
+		if (definedStereo.size() > 0) {
+			for (Atom atom : definedStereo) {
+				atom.setStereoGroup(group);
+			}
+		} else {
+			// else no information is given, assign them all to R and set the flag
+			for (Fragment fragment : possibleFragments) {
+				List<Atom> atomList = fragment.getAtomList();
+				for (Atom potentialStereoAtom : atomList) {
+				  if (notExplicitlyDefinedStereoCentreMap.containsKey(potentialStereoAtom)){
+						applyStereoChemistryToStereoCentre(potentialStereoAtom,
+																							 notExplicitlyDefinedStereoCentreMap.get(potentialStereoAtom),
+																							 "R");
+						potentialStereoAtom.setStereoGroup(group);
+						notExplicitlyDefinedStereoCentreMap.remove(potentialStereoAtom);
+					}
 				}
 			}
 		}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryHandler.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryHandler.java
@@ -298,10 +298,10 @@ class StereochemistryHandler {
 		for (int i = 0; i < cipOrderedAtoms.size() -1; i++) {//from highest to lowest (true for S) hence atomParity 1 for S
 			atomRefs4[i+1] = cipOrderedAtoms.get(i);
 		}
-		if (rOrS.equals("R") || rOrS.equals("RS")){
+		if (rOrS.equals("R")) {
 			atom.setAtomParity(atomRefs4, -1);
 		}
-		else if (rOrS.equals("S") || rOrS.equals("SR")){
+		else if (rOrS.equals("S")) {
 			atom.setAtomParity(atomRefs4, 1);
 		}
 		else{

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/XmlDeclarations.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/XmlDeclarations.java
@@ -189,6 +189,9 @@ class XmlDeclarations {
 	/**The semantic meaning of the token. Exact meaning is dependent on the element type e.g. SMILES for a group but a number for a multiplier*/
 	static final String VALUE_ATR ="value";
 
+	/**The stereo group (absolute, racemic, relative)  */
+	static final String STEREOGROUP_ATR ="stereoGroup";
+
 	/**The type of the token. Possible values are enumerated with strings ending in _TYPE_VAL */
 	static final String TYPE_ATR = "type";
 
@@ -361,6 +364,12 @@ class XmlDeclarations {
 
 	/**This stereochemistry element conveys E/Z stereochemistry*/
 	static final String E_OR_Z_TYPE_VAL ="EorZ";
+
+	/** The entire molecules is racemic and nothing else known. */
+	static final String RAC_TYPE_VAL ="RAC";
+
+	/** The entire molecules is relative and nothing else known (less common). */
+	static final String REL_TYPE_VAL ="REL";
 
 	/**This group is a sulfur/selenium/tellurium acid with the acidic hydroxy missing*/
 	static final String CHALCOGENACIDSTEM_TYPE_VAL ="chalcogenAcidStem";

--- a/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/regexTokens.xml
+++ b/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/regexTokens.xml
@@ -70,7 +70,7 @@
 	<regex name="%relativeOrientationStereochemTerm%" regex="((%locant%-?)?([eE][xX][oO]|[eE][nN][dD][oO]|[sS][yY][nN]|[aA][nN][tT][iI]))"/>
 	<regex name="%axialStereoTerm%" regex="(M|P|Ra|Sa|Sp|Rp)"/>
 	<regex name="%cisTransOptionallyLocanted%" regex="((%locantTypes%-?)?([cC][iI][sS]|[tT][rR][aA][nN][sS]))"/>
-	<regex name="%stereochemPossibilities%" regex="(%locantTypes%?([EZez]|EZ|ez|[RSrs](\^?\*)?|RS|R/S|rs|r/s|SR)|%cisTransOptionallyLocanted%|%alphaBetaLocant%|%relativeOrientationStereochemTerm%|%axialStereoTerm%)"/>
+	<regex name="%stereochemPossibilities%" regex="(%locantTypes%?([EZez]|EZ|ez|[RSrs](\^?\*)?|RS|RorS|SorR|RandS|SandR|R/S|rs|r/s|SR)|%cisTransOptionallyLocanted%|%alphaBetaLocant%|%relativeOrientationStereochemTerm%|%axialStereoTerm%)"/>
 	<regex name="%relativeOrRacemic%" regex="([rR][eE][lL]|[rR][aA][cC](\.|[eE][mM](\.|[iI][cC])?)?)"/>
 	<regexToken regex="(%relativeOrRacemic%-)?%openBracket%%stereochemPossibilities%([,-]%stereochemPossibilities%)*%closeBracket%-?|%openBracket%%relativeOrRacemic%%closeBracket%-?|%relativeOrRacemic%-" symbol="E" type="stereochemistryBracket" tagname="stereoChemistry" determinise="yes" />
 	<regexToken regex="([rct]-%allLocantForms%,)*[rct]-(%allLocantForms%-|%formsWhereHyphenIsOptional%)" symbol="Ê" type="relativeCisTrans" tagname="stereoChemistry" determinise="yes" /><!--relative/cis/trans descriptor-->

--- a/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/ComponentGeneration_StereochemistryTest.java
+++ b/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/ComponentGeneration_StereochemistryTest.java
@@ -823,7 +823,11 @@ public class ComponentGeneration_StereochemistryTest {
 		processStereochemistry(substituent);
 
 		List<Element> children = substituent.getChildElements();
-		assertEquals(0, children.size());
+		assertEquals(1, children.size());
+		Element stereoElement = children.get(0);
+		assertEquals(STEREOCHEMISTRY_EL, stereoElement.getName());
+		assertEquals(null, stereoElement.getAttributeValue(LOCANT_ATR));
+		assertEquals(REL_TYPE_VAL, stereoElement.getAttributeValue(TYPE_ATR));
 	}
 	
 	//relativeCisTrans is only supported sufficiently to get constitutionally correct results i.e. locants extracted from the stereochemistry
@@ -971,7 +975,11 @@ public class ComponentGeneration_StereochemistryTest {
 		processStereochemistry(substituent);
 
 		List<Element> children = substituent.getChildElements();
-		assertEquals(0, children.size());
+		assertEquals(1, children.size());
+		Element stereoElement = children.get(0);
+		assertEquals(STEREOCHEMISTRY_EL, stereoElement.getName());
+		assertEquals(null, stereoElement.getAttributeValue(LOCANT_ATR));
+		assertEquals(RAC_TYPE_VAL, stereoElement.getAttributeValue(TYPE_ATR));
 	}
 	
 	@Test
@@ -983,7 +991,11 @@ public class ComponentGeneration_StereochemistryTest {
 		processStereochemistry(substituent);
 
 		List<Element> children = substituent.getChildElements();
-		assertEquals(0, children.size());
+		assertEquals(1, children.size());
+		Element stereoElement = children.get(0);
+		assertEquals(STEREOCHEMISTRY_EL, stereoElement.getName());
+		assertEquals(null, stereoElement.getAttributeValue(LOCANT_ATR));
+		assertEquals(RAC_TYPE_VAL, stereoElement.getAttributeValue(TYPE_ATR));
 	}
 
 	@Test
@@ -995,7 +1007,11 @@ public class ComponentGeneration_StereochemistryTest {
 		processStereochemistry(substituent);
 
 		List<Element> children = substituent.getChildElements();
-		assertEquals(0, children.size());
+		assertEquals(1, children.size());
+		Element stereoElement = children.get(0);
+		assertEquals(STEREOCHEMISTRY_EL, stereoElement.getName());
+		assertEquals(null, stereoElement.getAttributeValue(LOCANT_ATR));
+		assertEquals(RAC_TYPE_VAL, stereoElement.getAttributeValue(TYPE_ATR));
 	}
 	
 	@Test
@@ -1014,7 +1030,7 @@ public class ComponentGeneration_StereochemistryTest {
 		assertEquals("RS", newStereochemistryEl.getAttributeValue(VALUE_ATR));
 		assertEquals(R_OR_S_TYPE_VAL, newStereochemistryEl.getAttributeValue(TYPE_ATR));
 	}
-	
+
 	@Test
 	public void testRacemate10() throws ComponentGenerationException {
 		Element substituent = new GroupingEl(SUBSTITUENT_EL);
@@ -1024,8 +1040,14 @@ public class ComponentGeneration_StereochemistryTest {
 		processStereochemistry(substituent);
 
 		List<Element> children = substituent.getChildElements();
-		assertEquals(0, children.size());
+		assertEquals(1, children.size());
+		Element stereoElement = children.get(0);
+		assertEquals(STEREOCHEMISTRY_EL, stereoElement.getName());
+		assertEquals(null, stereoElement.getAttributeValue(LOCANT_ATR));
+		assertEquals(RAC_TYPE_VAL, stereoElement.getAttributeValue(TYPE_ATR));
 	}
+
+ // TODO (R or S)- (R and S)-
 
 	@Test
 	public void testRacemateEz1() throws ComponentGenerationException {

--- a/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/ComponentGeneration_StereochemistryTest.java
+++ b/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/ComponentGeneration_StereochemistryTest.java
@@ -865,7 +865,9 @@ public class ComponentGeneration_StereochemistryTest {
 		Element newStereochemistryEl = children.get(0);
 		assertEquals(STEREOCHEMISTRY_EL, newStereochemistryEl.getName());
 		assertEquals("2", newStereochemistryEl.getAttributeValue(LOCANT_ATR));
-		assertEquals("RS", newStereochemistryEl.getAttributeValue(VALUE_ATR));
+		assertEquals("R", newStereochemistryEl.getAttributeValue(VALUE_ATR));
+		assertEquals(StereoGroup.Rac.name(),
+								 newStereochemistryEl.getAttributeValue(STEREOGROUP_ATR));
 		assertEquals(R_OR_S_TYPE_VAL, newStereochemistryEl.getAttributeValue(TYPE_ATR));
 	}
 	
@@ -882,7 +884,9 @@ public class ComponentGeneration_StereochemistryTest {
 		Element newStereochemistryEl = children.get(0);
 		assertEquals(STEREOCHEMISTRY_EL, newStereochemistryEl.getName());
 		assertEquals(null, newStereochemistryEl.getAttributeValue(LOCANT_ATR));
-		assertEquals("RS", newStereochemistryEl.getAttributeValue(VALUE_ATR));
+		assertEquals("R", newStereochemistryEl.getAttributeValue(VALUE_ATR));
+		assertEquals(StereoGroup.Rac.name(),
+								 newStereochemistryEl.getAttributeValue(STEREOGROUP_ATR));
 		assertEquals(R_OR_S_TYPE_VAL, newStereochemistryEl.getAttributeValue(TYPE_ATR));
 	}
 	
@@ -899,7 +903,9 @@ public class ComponentGeneration_StereochemistryTest {
 		Element newStereochemistryEl = children.get(0);
 		assertEquals(STEREOCHEMISTRY_EL, newStereochemistryEl.getName());
 		assertEquals(null, newStereochemistryEl.getAttributeValue(LOCANT_ATR));
-		assertEquals("RS", newStereochemistryEl.getAttributeValue(VALUE_ATR));
+		assertEquals("R", newStereochemistryEl.getAttributeValue(VALUE_ATR));
+		assertEquals(StereoGroup.Rac.name(),
+								 newStereochemistryEl.getAttributeValue(STEREOGROUP_ATR));
 		assertEquals(R_OR_S_TYPE_VAL, newStereochemistryEl.getAttributeValue(TYPE_ATR));
 	}
 	
@@ -916,7 +922,9 @@ public class ComponentGeneration_StereochemistryTest {
 		Element newStereochemistryEl = children.get(0);
 		assertEquals(STEREOCHEMISTRY_EL, newStereochemistryEl.getName());
 		assertEquals(null, newStereochemistryEl.getAttributeValue(LOCANT_ATR));
-		assertEquals("SR", newStereochemistryEl.getAttributeValue(VALUE_ATR));
+		assertEquals("S", newStereochemistryEl.getAttributeValue(VALUE_ATR));
+		assertEquals(StereoGroup.Rac.name(),
+								 newStereochemistryEl.getAttributeValue(STEREOGROUP_ATR));
 		assertEquals(R_OR_S_TYPE_VAL, newStereochemistryEl.getAttributeValue(TYPE_ATR));
 	}
 
@@ -933,13 +941,17 @@ public class ComponentGeneration_StereochemistryTest {
 		Element newStereochemistryEl1 = children.get(0);
 		assertEquals(STEREOCHEMISTRY_EL, newStereochemistryEl1.getName());
 		assertEquals("2", newStereochemistryEl1.getAttributeValue(LOCANT_ATR));
-		assertEquals("RS", newStereochemistryEl1.getAttributeValue(VALUE_ATR));
+		assertEquals("R", newStereochemistryEl1.getAttributeValue(VALUE_ATR));
+		assertEquals(StereoGroup.Rac.name(),
+								 newStereochemistryEl1.getAttributeValue(STEREOGROUP_ATR));
 		assertEquals(R_OR_S_TYPE_VAL, newStereochemistryEl1.getAttributeValue(TYPE_ATR));
 		
 		Element newStereochemistryEl2 = children.get(1);
 		assertEquals(STEREOCHEMISTRY_EL, newStereochemistryEl2.getName());
 		assertEquals("4", newStereochemistryEl2.getAttributeValue(LOCANT_ATR));
-		assertEquals("SR", newStereochemistryEl2.getAttributeValue(VALUE_ATR));
+		assertEquals("S", newStereochemistryEl2.getAttributeValue(VALUE_ATR));
+		assertEquals(StereoGroup.Rac.name(),
+								 newStereochemistryEl2.getAttributeValue(STEREOGROUP_ATR));
 		assertEquals(R_OR_S_TYPE_VAL, newStereochemistryEl2.getAttributeValue(TYPE_ATR));
 	}
 	
@@ -956,13 +968,17 @@ public class ComponentGeneration_StereochemistryTest {
 		Element newStereochemistryEl1 = children.get(0);
 		assertEquals(STEREOCHEMISTRY_EL, newStereochemistryEl1.getName());
 		assertEquals("2", newStereochemistryEl1.getAttributeValue(LOCANT_ATR));
-		assertEquals("RS", newStereochemistryEl1.getAttributeValue(VALUE_ATR));
+		assertEquals("R", newStereochemistryEl1.getAttributeValue(VALUE_ATR));
+		assertEquals(StereoGroup.Rac.name(),
+								 newStereochemistryEl1.getAttributeValue(STEREOGROUP_ATR));
 		assertEquals(R_OR_S_TYPE_VAL, newStereochemistryEl1.getAttributeValue(TYPE_ATR));
 		
 		Element newStereochemistryEl2 = children.get(1);
 		assertEquals(STEREOCHEMISTRY_EL, newStereochemistryEl2.getName());
 		assertEquals("4", newStereochemistryEl2.getAttributeValue(LOCANT_ATR));
-		assertEquals("SR", newStereochemistryEl2.getAttributeValue(VALUE_ATR));
+		assertEquals("S", newStereochemistryEl2.getAttributeValue(VALUE_ATR));
+		assertEquals(StereoGroup.Rac.name(),
+								 newStereochemistryEl2.getAttributeValue(STEREOGROUP_ATR));
 		assertEquals(R_OR_S_TYPE_VAL, newStereochemistryEl2.getAttributeValue(TYPE_ATR));
 	}
 	
@@ -1027,7 +1043,9 @@ public class ComponentGeneration_StereochemistryTest {
 		Element newStereochemistryEl = children.get(0);
 		assertEquals(STEREOCHEMISTRY_EL, newStereochemistryEl.getName());
 		assertEquals(null, newStereochemistryEl.getAttributeValue(LOCANT_ATR));
-		assertEquals("RS", newStereochemistryEl.getAttributeValue(VALUE_ATR));
+		assertEquals("R", newStereochemistryEl.getAttributeValue(VALUE_ATR));
+		assertEquals(StereoGroup.Rac.name(),
+								 newStereochemistryEl.getAttributeValue(STEREOGROUP_ATR));
 		assertEquals(R_OR_S_TYPE_VAL, newStereochemistryEl.getAttributeValue(TYPE_ATR));
 	}
 

--- a/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryTest.java
+++ b/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryTest.java
@@ -221,6 +221,117 @@ public class StereochemistryTest {
 			assertEquals(stereoCentres.get(1).getStereoAtom(), stereoAtoms.get(0));
 		}
 	}
+
+	@Test
+	public void applyStereochemistryLocantedRSracemic() throws StructureBuildingException {
+		Fragment f         = n2s.parseChemicalName("(1RS,2SR)-2-(methylamino)-1-phenylpropan-1-ol").getStructure();
+		int      nRacAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null && atom.getStereoGroup() == StereoGroup.Rac) {
+				nRacAtoms++;
+			}
+		}
+		assertEquals(2, nRacAtoms);
+	}
+
+	@Test
+	public void applyStereochemistryLocantedRSrel() throws StructureBuildingException {
+		Fragment f         = n2s.parseChemicalName("(1R*,2S*)-2-(methylamino)-1-phenylpropan-1-ol").getStructure();
+		int      nRelAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null && atom.getStereoGroup() == StereoGroup.Rel) {
+				nRelAtoms++;
+			}
+		}
+		assertEquals(2, nRelAtoms);
+	}
+
+	@Test
+	public void applyStereochemistryLocantedPartialRac() throws StructureBuildingException {
+		Fragment f         = n2s.parseChemicalName("(1RS,2R)-2-(methylamino)-1-phenylpropan-1-ol").getStructure();
+		int      nRacAtoms = 0;
+		int      nAbsAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null) {
+				if (atom.getStereoGroup() == StereoGroup.Rac)
+					nRacAtoms++;
+				else if (atom.getStereoGroup() == StereoGroup.Abs)
+					nAbsAtoms++;
+			}
+		}
+		assertEquals(1, nRacAtoms);
+		assertEquals(1, nAbsAtoms);
+	}
+
+	@Test
+	public void applyStereochemistryLocantedPartialRel() throws StructureBuildingException {
+		Fragment f         = n2s.parseChemicalName("(1R*,2R)-2-(methylamino)-1-phenylpropan-1-ol").getStructure();
+		int      nRelAtoms = 0;
+		int      nAbsAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null) {
+				if (atom.getStereoGroup() == StereoGroup.Rel)
+					nRelAtoms++;
+				else if (atom.getStereoGroup() == StereoGroup.Abs)
+					nAbsAtoms++;
+			}
+		}
+		assertEquals(1, nRelAtoms);
+		assertEquals(1, nAbsAtoms);
+	}
+
+	@Test
+	public void applyStereochemistryRacemicUnlocanted() throws StructureBuildingException {
+		Fragment f         = n2s.parseChemicalName("rac-1-phenylethan-1-ol").getStructure();
+		int      nRacAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null) {
+				if (atom.getStereoGroup() == StereoGroup.Rac)
+					nRacAtoms++;
+			}
+		}
+		assertEquals(1, nRacAtoms);
+	}
+
+	@Test
+	public void applyStereochemistryRacemicMultipleUnlocanted() throws StructureBuildingException {
+		Fragment f = n2s.parseChemicalName("rac-2-(methylamino)-1-phenylpropan-1-ol").getStructure();
+		assertNotNull(f);
+		int      nRacAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null) {
+				if (atom.getStereoGroup() == StereoGroup.Rac)
+					nRacAtoms++;
+			}
+		}
+		assertEquals(2, nRacAtoms);
+	}
+
+	@Test
+	public void applyStereochemistryRelUnlocanted() throws StructureBuildingException {
+		Fragment f         = n2s.parseChemicalName("rel-1-phenylethan-1-ol").getStructure();
+		int      nRelAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null) {
+				if (atom.getStereoGroup() == StereoGroup.Rel)
+					nRelAtoms++;
+			}
+		}
+		assertEquals(1, nRelAtoms);
+	}
+
+	@Test
+	public void applyStereochemistryRelUnlocanted2() throws StructureBuildingException {
+		Fragment f         = n2s.parseChemicalName("(rac)-1-phenylethan-1-ol").getStructure();
+		int      nRacAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null) {
+				if (atom.getStereoGroup() == StereoGroup.Rac)
+					nRacAtoms++;
+			}
+		}
+		assertEquals(1, nRacAtoms);
+	}
 	
 	@Test
 	public void testCIPpriority1() throws StructureBuildingException {

--- a/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryTest.java
+++ b/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryTest.java
@@ -313,6 +313,12 @@ public class StereochemistryTest {
 		assertEnhancedStereo("(1R or S)-1-(1-pentyl-1H-pyrazol-5-yl)ethanol", 0, 1, 0);
 	}
 
+	@Test
+	public void applyStereochemistryRacCis() throws StructureBuildingException {
+		// racemic cis
+		assertEnhancedStereo("rac-cis-N4-(2,2-dimethyl-3,4-dihydro-3-oxo-2H-pyrido[3,2-b][1,4]oxazin-6-yl)-N2-[6-[2,6-dimethylmorpholino)pyridin-3-yl]-5-fluoro-2,4-pyrimidinediamine", 2, 0, 0);
+	}
+
 	// US20080015199A1_2830
 	// probably better to support via composite entity like techniques
 	@Ignore

--- a/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryTest.java
+++ b/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryTest.java
@@ -302,6 +302,12 @@ public class StereochemistryTest {
 	}
 
 	@Test
+	public void prefixTakesPrecedence() throws StructureBuildingException {
+		assertEnhancedStereo("rac-(R*)-1-phenylethan-1-ol", 1, 0, 0);
+		assertEnhancedStereo("rel-(RS)-1-phenylethan-1-ol", 0, 1, 0);
+	}
+
+	@Test
 	public void applyStereochemistryLocantedRorS() throws StructureBuildingException {
 		// just for James Davidson, should be rel-(1R)- or 1R*
 		assertEnhancedStereo("(1R or S)-1-(1-pentyl-1H-pyrazol-5-yl)ethanol", 0, 1, 0);

--- a/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryTest.java
+++ b/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import uk.ac.cam.ch.wwmm.opsin.BondStereo.BondStereoValue;
@@ -323,6 +324,48 @@ public class StereochemistryTest {
 	@Test
 	public void applyStereochemistryRelUnlocanted2() throws StructureBuildingException {
 		Fragment f         = n2s.parseChemicalName("(rac)-1-phenylethan-1-ol").getStructure();
+		int      nRacAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null) {
+				if (atom.getStereoGroup() == StereoGroup.Rac)
+					nRacAtoms++;
+			}
+		}
+		assertEquals(1, nRacAtoms);
+	}
+
+	@Test
+	public void applyStereochemistryLocantedRorS() throws StructureBuildingException {
+		// just for James Davidson, should be 1R*
+		Fragment f         = n2s.parseChemicalName("(1R or S)-1-(1-pentyl-1H-pyrazol-5-yl)ethanol").getStructure();
+		int      nRacAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null) {
+				if (atom.getStereoGroup() == StereoGroup.Rel)
+					nRacAtoms++;
+			}
+		}
+		assertEquals(1, nRacAtoms);
+	}
+
+	// US20080015199A1_2830
+	// probably better to support via composite entity like techniques
+	@Ignore
+	public void applyStereochemistryRelUnlocantedRAndS() throws StructureBuildingException {
+		Fragment f         = n2s.parseChemicalName("(R) and (S)-4-{3-[(4-Carbamimidoylphenylamino)-(3,5-dimethoxyphenyl)methyl]-5-oxo-4,5-dihydro-[1,2,4]triazol-1-yl}thiazole-5-carboxylic acid").getStructure();
+		int      nRacAtoms = 0;
+		for (Atom atom : f.getAtomList()) {
+			if (atom.getAtomParity() != null) {
+				if (atom.getStereoGroup() == StereoGroup.Rac)
+					nRacAtoms++;
+			}
+		}
+		assertEquals(1, nRacAtoms);
+	}
+
+	@Test
+	public void applyStereochemistryLocantedRandS() throws StructureBuildingException {
+		Fragment f         = n2s.parseChemicalName("(1R and S)-1-(1-pentyl-1H-pyrazol-5-yl)ethanol").getStructure();
 		int      nRacAtoms = 0;
 		for (Atom atom : f.getAtomList()) {
 			if (atom.getAtomParity() != null) {

--- a/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryTest.java
+++ b/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/StereochemistryTest.java
@@ -223,129 +223,88 @@ public class StereochemistryTest {
 		}
 	}
 
-	@Test
-	public void applyStereochemistryLocantedRSracemic() throws StructureBuildingException {
-		Fragment f         = n2s.parseChemicalName("(1RS,2SR)-2-(methylamino)-1-phenylpropan-1-ol").getStructure();
+	/**
+	 * Check the number of stereo atoms in a molecule name are assigned to the
+	 * correct groups.
+	 * @param name chemical name
+	 * @param nRacExp number of stereo centers expected to be racemic
+	 * @param nRelExp number of stereo centers expected to be relative
+	 * @param nAbsExp number of stereo centers expected to be absolute
+	 */
+	void assertEnhancedStereo(String name, int nRacExp, int nRelExp, int nAbsExp) {
+		Fragment f = n2s.parseChemicalName(name).getStructure();
 		int      nRacAtoms = 0;
+		int      nRelAtoms = 0;
+		int      nAbsAtoms = 0;
 		for (Atom atom : f.getAtomList()) {
-			if (atom.getAtomParity() != null && atom.getStereoGroup() == StereoGroup.Rac) {
-				nRacAtoms++;
+			if (atom.getAtomParity() != null) {
+				if (atom.getStereoGroup() == StereoGroup.Rac)
+					nRacAtoms++;
+				if (atom.getStereoGroup() == StereoGroup.Rel)
+					nRelAtoms++;
+				else if (atom.getStereoGroup() == StereoGroup.Abs)
+					nAbsAtoms++;
 			}
 		}
-		assertEquals(2, nRacAtoms);
+		assertEquals("Incorrect number of racemic stereo centers", nRacExp, nRacAtoms);
+		assertEquals("Incorrect number of relative stereo centers",nRelExp, nRelAtoms);
+		assertEquals("Incorrect number of absolute stereo centers",nAbsExp, nAbsAtoms);
+	}
+
+	@Test
+	public void applyStereochemistryLocantedRSracemic() throws StructureBuildingException {
+		assertEnhancedStereo("(1RS,2SR)-2-(methylamino)-1-phenylpropan-1-ol", 2, 0, 0);
 	}
 
 	@Test
 	public void applyStereochemistryLocantedRSrel() throws StructureBuildingException {
-		Fragment f         = n2s.parseChemicalName("(1R*,2S*)-2-(methylamino)-1-phenylpropan-1-ol").getStructure();
-		int      nRelAtoms = 0;
-		for (Atom atom : f.getAtomList()) {
-			if (atom.getAtomParity() != null && atom.getStereoGroup() == StereoGroup.Rel) {
-				nRelAtoms++;
-			}
-		}
-		assertEquals(2, nRelAtoms);
+		assertEnhancedStereo("(1R*,2S*)-2-(methylamino)-1-phenylpropan-1-ol", 0, 2, 0);
 	}
 
 	@Test
 	public void applyStereochemistryLocantedPartialRac() throws StructureBuildingException {
-		Fragment f         = n2s.parseChemicalName("(1RS,2R)-2-(methylamino)-1-phenylpropan-1-ol").getStructure();
-		int      nRacAtoms = 0;
-		int      nAbsAtoms = 0;
-		for (Atom atom : f.getAtomList()) {
-			if (atom.getAtomParity() != null) {
-				if (atom.getStereoGroup() == StereoGroup.Rac)
-					nRacAtoms++;
-				else if (atom.getStereoGroup() == StereoGroup.Abs)
-					nAbsAtoms++;
-			}
-		}
-		assertEquals(1, nRacAtoms);
-		assertEquals(1, nAbsAtoms);
+		assertEnhancedStereo("(1RS,2R)-2-(methylamino)-1-phenylpropan-1-ol", 1, 0, 1);
 	}
 
 	@Test
 	public void applyStereochemistryLocantedPartialRel() throws StructureBuildingException {
-		Fragment f         = n2s.parseChemicalName("(1R*,2R)-2-(methylamino)-1-phenylpropan-1-ol").getStructure();
-		int      nRelAtoms = 0;
-		int      nAbsAtoms = 0;
-		for (Atom atom : f.getAtomList()) {
-			if (atom.getAtomParity() != null) {
-				if (atom.getStereoGroup() == StereoGroup.Rel)
-					nRelAtoms++;
-				else if (atom.getStereoGroup() == StereoGroup.Abs)
-					nAbsAtoms++;
-			}
-		}
-		assertEquals(1, nRelAtoms);
-		assertEquals(1, nAbsAtoms);
+		assertEnhancedStereo("(1R*,2R)-2-(methylamino)-1-phenylpropan-1-ol", 0, 1, 1);
+	}
+
+	@Test
+	public void applyStereochemistryRacSlash() throws StructureBuildingException {
+		assertEnhancedStereo("(1R/S,2R)-2-(methylamino)-1-phenylpropan-1-ol", 1, 0, 1);
+	}
+
+	@Test
+	public void applyStereochemistryRelHatStar() throws StructureBuildingException {
+		assertEnhancedStereo("(1R^*,2S^*)-2-(methylamino)-1-phenylpropan-1-ol", 0, 2, 0);
 	}
 
 	@Test
 	public void applyStereochemistryRacemicUnlocanted() throws StructureBuildingException {
-		Fragment f         = n2s.parseChemicalName("rac-1-phenylethan-1-ol").getStructure();
-		int      nRacAtoms = 0;
-		for (Atom atom : f.getAtomList()) {
-			if (atom.getAtomParity() != null) {
-				if (atom.getStereoGroup() == StereoGroup.Rac)
-					nRacAtoms++;
-			}
-		}
-		assertEquals(1, nRacAtoms);
+		assertEnhancedStereo("rac-1-phenylethan-1-ol", 1, 0, 0);
 	}
 
 	@Test
 	public void applyStereochemistryRacemicMultipleUnlocanted() throws StructureBuildingException {
-		Fragment f = n2s.parseChemicalName("rac-2-(methylamino)-1-phenylpropan-1-ol").getStructure();
-		assertNotNull(f);
-		int      nRacAtoms = 0;
-		for (Atom atom : f.getAtomList()) {
-			if (atom.getAtomParity() != null) {
-				if (atom.getStereoGroup() == StereoGroup.Rac)
-					nRacAtoms++;
-			}
-		}
-		assertEquals(2, nRacAtoms);
+		assertEnhancedStereo("rac-2-(methylamino)-1-phenylpropan-1-ol", 2, 0, 0);
 	}
 
 	@Test
 	public void applyStereochemistryRelUnlocanted() throws StructureBuildingException {
-		Fragment f         = n2s.parseChemicalName("rel-1-phenylethan-1-ol").getStructure();
-		int      nRelAtoms = 0;
-		for (Atom atom : f.getAtomList()) {
-			if (atom.getAtomParity() != null) {
-				if (atom.getStereoGroup() == StereoGroup.Rel)
-					nRelAtoms++;
-			}
-		}
-		assertEquals(1, nRelAtoms);
+		assertEnhancedStereo("rel-1-phenylethan-1-ol", 0, 1, 0);
 	}
 
 	@Test
 	public void applyStereochemistryRelUnlocanted2() throws StructureBuildingException {
-		Fragment f         = n2s.parseChemicalName("(rac)-1-phenylethan-1-ol").getStructure();
-		int      nRacAtoms = 0;
-		for (Atom atom : f.getAtomList()) {
-			if (atom.getAtomParity() != null) {
-				if (atom.getStereoGroup() == StereoGroup.Rac)
-					nRacAtoms++;
-			}
-		}
-		assertEquals(1, nRacAtoms);
+		assertEnhancedStereo("(rac)-1-phenylethan-1-ol", 1, 0, 0);
 	}
 
 	@Test
 	public void applyStereochemistryLocantedRorS() throws StructureBuildingException {
-		// just for James Davidson, should be 1R*
-		Fragment f         = n2s.parseChemicalName("(1R or S)-1-(1-pentyl-1H-pyrazol-5-yl)ethanol").getStructure();
-		int      nRacAtoms = 0;
-		for (Atom atom : f.getAtomList()) {
-			if (atom.getAtomParity() != null) {
-				if (atom.getStereoGroup() == StereoGroup.Rel)
-					nRacAtoms++;
-			}
-		}
-		assertEquals(1, nRacAtoms);
+		// just for James Davidson, should be rel-(1R)- or 1R*
+		assertEnhancedStereo("(1R or S)-1-(1-pentyl-1H-pyrazol-5-yl)ethanol", 0, 1, 0);
 	}
 
 	// US20080015199A1_2830

--- a/opsin-inchi/src/main/java/uk/ac/cam/ch/wwmm/opsin/NameToInchi.java
+++ b/opsin-inchi/src/main/java/uk/ac/cam/ch/wwmm/opsin/NameToInchi.java
@@ -163,7 +163,7 @@ public class NameToInchi {
 
 		for (Atom atom : atomList) {//add atomParities
 			AtomParity atomParity =atom.getAtomParity();
-        	if (atomParity != null){
+        	if (atomParity != null && atomParity.getStereoGroup() != StereoGroup.Rac){
         		Atom[] atomRefs4 = atomParity.getAtomRefs4();
 				int[] atomRefs4AsInt = new int[4];
 				for (int i = 0; i < atomRefs4.length; i++) {

--- a/opsin-inchi/src/test/java/uk/ac/cam/ch/wwmm/opsin/InchiOutputTest.java
+++ b/opsin-inchi/src/test/java/uk/ac/cam/ch/wwmm/opsin/InchiOutputTest.java
@@ -60,4 +60,9 @@ public class InchiOutputTest {
 	public void testParseToStdInChIKey(){
 		assertEquals("DLFVBJFMPXGRIB-UHFFFAOYSA-N", n2i.parseToStdInchiKey("acetamide"));
 	}
+
+	@Test
+	public void ignoreRacemicStereoInInchi() throws StructureBuildingException{
+		assertEquals("InChI=1/C8H10O/c1-7(9)8-5-3-2-4-6-8/h2-7,9H,1H3", n2i.parseToInchi("rac-(R)-1-phenylethan-1-ol"));
+	}
 }


### PR DESCRIPTION
Adds a new "stereo group" field to stereogenic atoms, the group can either be Rac(emic), Rel(ative), or Abs(olute). Normally enhanced stereo support has sub-groups, e.g. Rac1/&1, Rac2/&2, etc however to my knowledge there is no official way to represent these in IUPAC - maybe one could infer it with bracket nesting. I think more likely is the most common use cases would be mixing the different groups rather than different sub-groups and that is supported by IUPAC. For example it makes sense you can have some atoms with absolute stereo and some as racemic and/or relative.

- An open question I had was whether "rac-" and "rel-" prefixes in isolation should be allowed on structures with multiple stereocenters. I originally handled these by just putting in an unlocanted "dummy" element which meant only the first atom encoutered would be set, I then settled on simply adding a new type "REL/RAC" that instruct the stereo handler to set every stereo atom it can find. I think maybe it should be a warning if you set more than one atom config in this function?
- The SMILESWriter was hard to unit test since the reader doesn't actually read stereochemistry, but since the changes are minimal should be easy to confirm it's correct.
- The CXSMILES documentation reports the `|r|` as the "relative flag", however it's interpretation is to be as though the MOLfile chiral flag is 0. BIOVIA document that these cases should be read as racemic (see [Page 251](http://help.accelrysonline.com/insight/2017/content/pdf_files/bioviachemicalrepresentation2017.pdf)). So I think ChemAxon just goofed it up - note they also distinguish ABS from normal SMILES stereo when matching which doesn't make sense - oh well. Anyways as you can see if all atoms end up being `&1` we emit a `r` as it is cleaner but perhaps given the possibly ambiguity may be confusing.

# Examples

Here are some generated outputs (running live on CDK depict).

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=C1(%3DCC%3DCC%3DC1)%5BC%40%40H%5D(C)O%20%7C%24_AV%3A1%3B2%3B3%3B4%3B5%3B6%3B1%3B2%3BO%24%2Cr%7C&w=-1&h=-1&abbr=off&hdisp=bridgehead&showtitle=false&zoom=1.25&annotate=none&f=1&r=0)
**(rac)-1-phenylethan-1-ol**
```
C1(=CC=CC=C1)[C@@H](C)O |$_AV:1;2;3;4;5;6;1;2;O$,r|
```

<hr/>

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=CN%5BC%40H%5D(%5BC%40H%5D(O)C1%3DCC%3DCC%3DC1)C%20%7C%24_AV%3A1%3BN%3B2%3B1%3BO%3B1%3B2%3B3%3B4%3B5%3B6%3B3%24%2Co1%3A2%2C3%7C&w=-1&h=-1&abbr=off&hdisp=bridgehead&showtitle=false&zoom=1.25&annotate=none&f=1&r=0)
**(1R\*,2S\*)-2-(methylamino)-1-phenylpropan-1-ol**
```
CN[C@H]([C@H](O)C1=CC=CC=C1)C |$_AV:1;N;2;1;O;1;2;3;4;5;6;3$,o1:2,3|
```

<hr/>

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=CN%5BC%40H%5D(%5BC%40H%5D(O)C1%3DCC%3DCC%3DC1)C%20%7C%24_AV%3A1%3BN%3B2%3B1%3BO%3B1%3B2%3B3%3B4%3B5%3B6%3B3%24%2Ca%3A2%2C%261%3A3%7C&w=-1&h=-1&abbr=off&hdisp=bridgehead&showtitle=false&zoom=1.25&annotate=none&f=1&r=0)
**(1RS,2S)-2-(methylamino)-1-phenylpropan-1-ol**
```
CN[C@H]([C@H](O)C1=CC=CC=C1)C |$_AV:1;N;2;1;O;1;2;3;4;5;6;3$,a:2,&1:3|
```

<hr/>

![](https://www.simolecule.com/cdkdepict/depict/bot/svg?smi=C(CCCC)N1N%3DCC%3DC1%5BC%40%40H%5D(C)O%20%7C%24_AV%3A1%3B2%3B3%3B4%3B5%3B1%3B2%3B3%3B4%3B5%3B1%3B2%3BO%24%2Cr%7C&w=-1&h=-1&abbr=off&hdisp=bridgehead&showtitle=false&zoom=1.25&annotate=none&r=178)
**(1R and S)-1-(1-pentyl-1H-pyrazol-5-yl)ethanol**
```
C(CCCC)N1N=CC=C1[C@@H](C)O |$_AV:1;2;3;4;5;1;2;3;4;5;1;2;O$,r|
```

<hr/>


