### PR TITLE
Allow "alanine nitrile" as a peptide suffix.

### DIFF
--- a/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/suffixApplicability.xml
+++ b/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/suffixApplicability.xml
@@ -127,6 +127,7 @@ The value of the suffix elements corresponds to the value attribute of the suffi
 		<suffix value="oyl">oyl</suffix>
 		<suffix value="yl">oyl</suffix>
 		<suffix value="oMeaningYl">yl</suffix><!--e.g. glycino-->
+		<suffix value="nitrile">nitrile</suffix>
 		<suffix value="locantedAminoAcidOrCarbohydrateYl">yl</suffix><!--locanted yl means something different to unlocanted yl!-->
 		<suffix value="locantedAminoAcidOrCarbohydrateYlidene">ylidene</suffix>
 	</groupType>


### PR DESCRIPTION
Roger - Pfizer’s new COVID pill, PF-07321332, is a peptide nitrile, so
there’ll be an interest in this C-terminal modification, just like “aldehyde”, “amide”,
“thial”, “thioamide”