### PR TITLE
Deaza

### DIFF
--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StructureBuildingMethods.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StructureBuildingMethods.java
@@ -642,7 +642,16 @@ class StructureBuildingMethods {
 			String locant = heteroatomEl.getAttributeValue(LOCANT_ATR);
 			if(locant != null) {
 				Atom heteroatom = state.fragManager.getHeteroatom(heteroatomEl.getAttributeValue(VALUE_ATR));
-				Atom atomToBeReplaced =thisFrag.getAtomByLocantOrThrow(locant);
+				Atom atomToBeReplaced = thisFrag.getAtomByLocantOrThrow(locant);
+
+				String restrict = heteroatomEl.getAttributeValue(ONLY_REPLACE_ATR);
+				if (restrict != null) {
+					if (ChemEl.valueOf(restrict) != atomToBeReplaced.getElement()) {
+						throw new StructureBuildingException("The replacement term " + heteroatomEl.getValue() + " was used on an atom that already is not an " + restrict);
+					}
+				}
+
+
 				if (heteroatom.getElement() == atomToBeReplaced.getElement() && heteroatom.getCharge() == atomToBeReplaced.getCharge()){
 					throw new StructureBuildingException("The replacement term " +heteroatomEl.getValue() +" was used on an atom that already is a " + heteroatom.getElement());
 				}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StructureBuildingMethods.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StructureBuildingMethods.java
@@ -647,7 +647,7 @@ class StructureBuildingMethods {
 				String restrict = heteroatomEl.getAttributeValue(ONLY_REPLACE_ATR);
 				if (restrict != null) {
 					if (ChemEl.valueOf(restrict) != atomToBeReplaced.getElement()) {
-						throw new StructureBuildingException("The replacement term " + heteroatomEl.getValue() + " was used on an atom that already is not an " + restrict);
+						throw new StructureBuildingException("The replacement term " + heteroatomEl.getValue() + " was used on an atom that is not an " + restrict);
 					}
 				}
 

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/XmlDeclarations.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/XmlDeclarations.java
@@ -192,6 +192,9 @@ class XmlDeclarations {
 	/**The stereo group (absolute, racemic, relative)  */
 	static final String STEREOGROUP_ATR ="stereoGroup";
 
+	/**Restriction on some locant/group */
+	static final String ONLY_REPLACE_ATR ="onlyReplace";
+
 	/**The type of the token. Possible values are enumerated with strings ending in _TYPE_VAL */
 	static final String TYPE_ATR = "type";
 

--- a/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/heteroAtoms.xml
+++ b/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/heteroAtoms.xml
@@ -18,6 +18,7 @@
 	<token value="[SbH3]">stiba</token>
 	<token value="[BiH3]">bisma</token>
 	<token value="C">carba</token>
+	<token value="C" onlyReplace="N">deaza</token>
 	<token value="[SiH4]">sila</token>
 	<token value="[GeH4]">germa</token>
 	<token value="[SnH4]">stanna</token>

--- a/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/tokenLists.dtd
+++ b/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/tokenLists.dtd
@@ -38,6 +38,7 @@ ignoreWhenWritingXML == Tells the parser not to form an XML element out of these
         suffixAppliesToByDefault CDATA #IMPLIED
         usableAsAJoiner CDATA #IMPLIED
         stereoGroup CDATA #IMPLIED
+        onlyReplace CDATA #IMPLIED
 >
 <!--
   (the #PCDATA inside the tag) = the string to match
@@ -64,4 +65,6 @@ ignoreWhenWritingXML == Tells the parser not to form an XML element out of these
   suffixAppliesTo == comma separated IDs indicating where the suffix following a group should be applied. Currently used to direct the formation of trivial di-acids. IDs are relative to this particular fragment first atom = 1)
   suffixAppliesToByDefault == same as suffixAppliesTo but can be overridden by given locants
   usableAsAJoiner == yes or absent. Can the substituent be implicitly bracketed to a previous substitutent e.g. methylaminobenzene becomes (methylamino)benzene as amino has this attribute
+  stereoGroup == stereo group racemic/relative indication
+  onlyReplace == Hetero atom replacement restriction (deaza)
   -->


### PR DESCRIPTION
Not clear where best to add tests, let me know.

7-Deaza-2′-deoxy-guanosine-5′-triphosphate
```
P(O)(=O)(OP(=O)(O)OP(=O)(O)O)OC[C@@H]1[C@H](C[C@@H](O1)N1C=CC=2C(=O)NC(N)=NC12)O

```
deaza-pyridine
```
C1=CC=CC=C1

```
deaza-morpholine
```
C1CCOCC1
APPEARS_AMBIGUOUS: Heteroatom replacement on morpholin
```
1-deaza-morpholine
```
null
The replacement term deaza was used on an atom that already is not an N
```

- No obvious attribute to reuse so created "onlyReplace"
- Technically deaza-morpholine is unambiguous... but it still works

Roger:

```
Searching “deaza” in Google reveals that it’s widely used in IUPAC-like names.
As an example, one of the top hits I see is Sigma Aldrich:
https://www.sigmaaldrich.com/catalog/product/roche/10988537001
which is for the compound
7-Deaza-2′-deoxy-guanosine-5′-triphosphate
which isn’t currently supported by OPSIN.
Interestingly, the hack/workaround is that replacing “deaza” with “carba”
results in a name that is interpretable by OPSIN, hence the suggestion is
to treat “deaza” as synonym for “carba”.
 
The one complaint that Daniel may have is that deaza should probably generate
a warning when the original atom is not nitrogen, unlike “carba” which forces
the element to carbon irrespective of the original element. Hence for bonus
points, it might be nice to check whether there’s a place in the current code,
where a simple warning may be thrown (though this isn’t strictly required).
```
 
