### PR TITLE
Improvements to the SMILESWriter

### DIFF
--- a/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/NameToStructureConfigurationsTest.java
+++ b/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/NameToStructureConfigurationsTest.java
@@ -45,7 +45,7 @@ public class NameToStructureConfigurationsTest {
 
 			n2sConfig.setOutputRadicalsAsWildCardAtoms(true);
 			or = n2s.parseChemicalName("methyl", n2sConfig);
-			assertEquals("C*", or.getSmiles());
+			assertEquals("*C", or.getSmiles());
 		}
 
 		@Test
@@ -58,7 +58,7 @@ public class NameToStructureConfigurationsTest {
 			
 			n2sConfig.setOutputRadicalsAsWildCardAtoms(true);
 			or = n2s.parseChemicalName("methyl", n2sConfig);
-			assertEquals("C* |$;_AP1$|", or.getSmiles(SmilesOptions.CXSMILES_ATOM_LABELS));
+			assertEquals("*C |$_AP1$|", or.getSmiles(SmilesOptions.CXSMILES_ATOM_LABELS));
 		}
 		
 		@Test

--- a/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/SMILESWriterTest.java
+++ b/opsin-core/src/test/java/uk/ac/cam/ch/wwmm/opsin/SMILESWriterTest.java
@@ -242,7 +242,7 @@ public class SMILESWriterTest {
 		Fragment f = fm.buildSMILES("[H][R]");
 		fm.makeHydrogensExplicit();
 		String smiles = SMILESWriter.generateSmiles(f);
-		assertEquals("[H]*", smiles);
+		assertEquals("*[H]", smiles);
 	}
 	
 	@Test
@@ -461,5 +461,15 @@ public class SMILESWriterTest {
 		assertEquals("2", atoms.get(1).getLocants().get(0));
 		assertEquals("alpha", atoms.get(1).getLocants().get(1));
 		assertEquals("2'", atoms.get(1).getLocants().get(2));
+	}
+
+	@Test
+	void testAtomClassEmitted() throws StructureBuildingException {
+		Fragment f = fm.buildSMILES("CCO");
+		fm.makeHydrogensExplicit();
+		assertEquals("CCO", SMILESWriter.generateSmiles(f));
+		for (Atom a : f)
+			a.setProperty(Atom.ATOM_CLASS, a.getID());
+		assertEquals("[CH3:1][CH2:2][OH:3]", SMILESWriter.generateSmiles(f));
 	}
 }


### PR DESCRIPTION
- Inter fragment bonds should not be traversed
- Emit * (ChemEl.R) atoms first, this yields prettier output and smaller CXSMILES
- Minor optimisation, collect up the start/root atoms in the first pass for a simpler and more efficient write pass