### PR TITLE
WIP: Add in an option "force covalent" which can control the structur…

### DIFF
--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/FragmentManager.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/FragmentManager.java
@@ -617,6 +617,16 @@ class FragmentManager {
 		return Collections.unmodifiableSet(interFragmentBonds);
 	}
 
+	Bond getInterFragmentBond(Atom from, Atom to) {
+		for (Bond bond : getInterFragmentBonds(from.getFrag())) {
+			if (bond.getFromAtom().equals(from) && bond.getToAtom().equals(to) ||
+				bond.getToAtom().equals(from) && bond.getFromAtom().equals(to)) {
+				return bond;
+			}
+		}
+		return null;
+	}
+
 	/**
 	 * Create a new Atom of the given element belonging to the given fragment
 	 * @param chemEl

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/NameToStructureConfig.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/NameToStructureConfig.java
@@ -18,6 +18,7 @@ public class NameToStructureConfig implements Cloneable {
 	private boolean detailedFailureAnalysis = false;
 	private boolean interpretAcidsWithoutTheWordAcid = false;
 	private boolean warnRatherThanFailOnUninterpretableStereochemistry = false;
+	private boolean forceCovalent = false;
 
 	/**
 	 * Constructs a NameToStructureConfig with default settings:
@@ -114,6 +115,15 @@ public class NameToStructureConfig implements Cloneable {
 		this.warnRatherThanFailOnUninterpretableStereochemistry = warnRatherThanFailOnUninterpretableStereochemistry;
 	}
 
+
+	public void setForceCovalent(boolean forceCovalent) {
+		this.forceCovalent = forceCovalent;
+	}
+
+
+	public boolean isForceCovalent() {
+		return forceCovalent;
+	}
 
 	/**
 	 * Constructs a NameToStructureConfig with default settings:

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/Parser.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/Parser.java
@@ -147,7 +147,8 @@ class Parser {
 			 * <wr><wr>Carbonyl cyanide</wr> m-chlorophenyl hydrazone </wr>
 			 */
 			try {
-				wordRules.groupWordsIntoWordRules(moleculeEl, n2sConfig, allowSpaceRemoval, componentRatios);
+				wordRules.groupWordsIntoWordRules(moleculeEl, n2sConfig, allowSpaceRemoval, n2sConfig.isForceCovalent(),
+																					componentRatios);
 			} catch (ParsingException e) {
 				if(LOG.isDebugEnabled()) {
 					LOG.debug(e.getMessage(), e);

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StructureBuilder.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StructureBuilder.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -61,8 +62,9 @@ class StructureBuilder {
 		processOxidationNumbers(groupElements);
 		state.fragManager.convertSpareValenciesToDoubleBonds();
 		state.fragManager.checkValencies();
-		
+
 		manipulateStoichiometry(molecule, wordRules);
+		rebondCounterions();
 		
 		state.fragManager.makeHydrogensExplicit();
 
@@ -87,6 +89,64 @@ class StructureBuilder {
 		return uniFrag;
 	}
 
+	/* JWM - ideally to be removed */
+	private void rebondCounterions() {
+		int numPos = 0;
+		int numNeg = 0;
+		List<Atom> posAtoms = new ArrayList<>();
+		List<Atom> negAtoms = new ArrayList<>();
+		for (Fragment f : state.fragManager.getFragments()) {
+			for (Atom atom : f.getAtomList()) {
+				if (atom.getCharge() > 0) {
+					numPos++;
+					for (int i=0; i<atom.getCharge(); i++)
+						posAtoms.add(atom);
+				}
+				else if (atom.getCharge() < 0) {
+					numNeg++;
+					for (int i=0; i>atom.getCharge(); i--)
+						negAtoms.add(atom);
+				}
+			}
+		}
+
+
+		boolean isOkay = posAtoms.size() == negAtoms.size() &&
+						 (numPos == posAtoms.size() || numPos == 1) &&
+						 (numNeg == negAtoms.size() || numNeg == 1);
+
+		if (!isOkay)
+			return;
+
+		Set<Fragment> uniqueFrags = new HashSet<>();
+		for (Atom a : posAtoms) {
+			if (a.getImplicitHydrogenAllowed())
+				return;
+			uniqueFrags.add(a.getFrag());
+		}
+		for (Atom a : negAtoms) {
+			if (uniqueFrags.contains(a.getFrag()))
+				return;
+		}
+
+		for (int i=0; i<posAtoms.size(); i++) {
+			Atom posAtom = posAtoms.get(i);
+			Atom negAtom = negAtoms.get(i);
+
+			// leave as ionic
+			if (!state.n2sConfig.isForceCovalent() &&
+				!FragmentTools.isCovalent(posAtom.getElement(), negAtom.getElement()))
+				continue;
+
+			Bond bond = state.fragManager.getInterFragmentBond(posAtom, negAtom);
+			if (bond != null)
+				bond.setOrder(bond.getOrder()+1);
+			else
+				state.fragManager.createBond(posAtom, negAtom, 1);
+			posAtom.setCharge(posAtom.getCharge()-1);
+			negAtom.setCharge(negAtom.getCharge()+1);
+		}
+	}
 
 	private void processWordRuleChildrenThenRule(Element wordRule) throws StructureBuildingException {
 		List<Element> wordRuleChildren = wordRule.getChildElements(WORDRULE_EL);
@@ -192,7 +252,7 @@ class StructureBuilder {
 		BuildResults substituentsBr = new BuildResults();
 		List<BuildResults> ateGroups = new ArrayList<>();
 		Map<BuildResults, String> buildResultsToLocant = new HashMap<>();//typically locant will be null
-		
+
 		for (Element word : words) {
 			resolveWordOrBracket(state, word);
 			BuildResults br = new BuildResults(word);
@@ -271,10 +331,17 @@ class StructureBuilder {
 				ateBr.removeFunctionalAtom(0);
 			}
 			String locant = buildResultsToLocant.get(ateBr);
-			if (locant ==null){//typical case
+			if (locant ==null ){ //typical case
 				Atom atomOnSubstituentToUse = getOutAtomTakingIntoAccountWhetherSetExplicitly(substituentsBr, 0);
-				state.fragManager.createBond(ateAtom, atomOnSubstituentToUse, 1);
-				substituentsBr.removeOutAtom(0);
+				if (state.n2sConfig.isForceCovalent() ||
+					FragmentTools.isCovalent(atomOnSubstituentToUse.getElement(), ateAtom.getElement())) {
+					state.fragManager.createBond(ateAtom, atomOnSubstituentToUse, 1);
+					substituentsBr.removeOutAtom(0);
+					ateAtom.neutraliseCharge();
+				} else {
+					atomOnSubstituentToUse.setCharge(atomOnSubstituentToUse.getCharge()+1);
+					substituentsBr.removeOutAtom(0);
+				}
 			}
 			else{
 				Integer outAtomPosition =null;
@@ -288,10 +355,16 @@ class StructureBuilder {
 					throw new StructureBuildingException("Unable to find substituent with locant: " + locant + " to form ester!");
 				}
 				Atom atomOnSubstituentToUse = substituentsBr.getOutAtom(outAtomPosition).getAtom();
-				state.fragManager.createBond(ateAtom, atomOnSubstituentToUse, 1);
-				substituentsBr.removeOutAtom(outAtomPosition);
+				if (state.n2sConfig.isForceCovalent() ||
+					FragmentTools.isCovalent(atomOnSubstituentToUse.getElement(), ateAtom.getElement())) {
+					state.fragManager.createBond(ateAtom, atomOnSubstituentToUse, 1);
+					substituentsBr.removeOutAtom(outAtomPosition);
+					ateAtom.neutraliseCharge();
+				} else {
+					atomOnSubstituentToUse.setCharge(atomOnSubstituentToUse.getCharge()+1);
+					substituentsBr.removeOutAtom(0);
+				}
 			}
-			ateAtom.neutraliseCharge();
 		}
 	}
 

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/WordRules.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/WordRules.java
@@ -235,8 +235,9 @@ class WordRules {
 	 * @param componentRatios 
 	 * @throws ParsingException
 	 */
-	void groupWordsIntoWordRules(Element moleculeEl, NameToStructureConfig n2sConfig, boolean allowSpaceRemoval, Integer[] componentRatios) throws ParsingException {
-		WordRulesInstance instance = new WordRulesInstance(moleculeEl, n2sConfig, allowSpaceRemoval, componentRatios);
+	void groupWordsIntoWordRules(Element moleculeEl, NameToStructureConfig n2sConfig, boolean allowSpaceRemoval,
+															 boolean forceCovalent, Integer[] componentRatios) throws ParsingException {
+		WordRulesInstance instance = new WordRulesInstance(moleculeEl, n2sConfig, allowSpaceRemoval, forceCovalent, componentRatios);
 		List<Element> wordEls = moleculeEl.getChildElements(WORD_EL);
 		//note that multiple words in wordEls may be later replaced by a wordRule element
 		for (int i = 0; i <wordEls.size(); i++) {
@@ -257,11 +258,13 @@ class WordRules {
 		private final boolean allowRadicals;
 		private final boolean allowSpaceRemoval;
 		private final Integer expectedNumOfComponents;
+		private final boolean forceCovalent;
 		
-		WordRulesInstance(Element moleculeEl, NameToStructureConfig n2sConfig, boolean allowSpaceRemoval, Integer[] componentRatios) {
+		WordRulesInstance(Element moleculeEl, NameToStructureConfig n2sConfig, boolean allowSpaceRemoval, boolean forceCovalent, Integer[] componentRatios) {
 			this.moleculeEl = moleculeEl;
 			this.allowRadicals = n2sConfig.isAllowRadicals();
 			this.allowSpaceRemoval = allowSpaceRemoval;
+			this.forceCovalent = forceCovalent;
 			this.expectedNumOfComponents = componentRatios != null ? componentRatios.length : null;
 		}
 		
@@ -394,7 +397,8 @@ class WordRules {
 								}
 								Element oxideWord = wordEls.get(i + 1);
 								ChemEl chemEl2 = getChemElFromWordWithFunctionalGroup(oxideWord);
-								if (!FragmentTools.isCovalent(chemEl1, chemEl2) || chemEl1 == ChemEl.Ag){
+
+								if (!forceCovalent && (!FragmentTools.isCovalent(chemEl1, chemEl2) || chemEl1 == ChemEl.Ag)){
 									Element oxideGroup = convertFunctionalGroupIntoGroup(oxideWord);
 									setOxideStructureAppropriately(oxideGroup, elementaryAtom);
 									applySimpleWordRule(wordEls, indexOfFirstWord, possibleElementaryAtomContainingWord);
@@ -405,7 +409,8 @@ class WordRules {
 								for (int j = 1; j < wordsInWordRule; j++) {
 									Element functionalGroup = wordEls.get(i + j);
 									ChemEl chemEl2 = getChemElFromWordWithFunctionalGroup(functionalGroup);
-									if (!FragmentTools.isCovalent(chemEl1, chemEl2)) {//use separate word rules for ionic components
+									// use separate word rules for ionic components (unless forceCovalent)
+									if (!forceCovalent && !FragmentTools.isCovalent(chemEl1, chemEl2)) {
 										boolean specialCaseCovalency = false;
 										if (chemEl2.isHalogen() && wordsInWordRule == 2) {
 											switch (chemEl1) {

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/WordRules.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/WordRules.java
@@ -398,7 +398,7 @@ class WordRules {
 								Element oxideWord = wordEls.get(i + 1);
 								ChemEl chemEl2 = getChemElFromWordWithFunctionalGroup(oxideWord);
 
-								if (!forceCovalent && (!FragmentTools.isCovalent(chemEl1, chemEl2) || chemEl1 == ChemEl.Ag)){
+								if (!forceCovalent && !FragmentTools.isCovalent(chemEl1, chemEl2) || chemEl1 == ChemEl.Ag){
 									Element oxideGroup = convertFunctionalGroupIntoGroup(oxideWord);
 									setOxideStructureAppropriately(oxideGroup, elementaryAtom);
 									applySimpleWordRule(wordEls, indexOfFirstWord, possibleElementaryAtomContainingWord);


### PR DESCRIPTION
…e output form.

I have playing around attempting to get OPSIN to consistently output either ionic or covalent molecules depending on a new flag. This primarily involves 3 changes:

1) A new option "forceCovalent" which overides "isCovalent"
2) Using "isCovalent" on the "ester" rule to check if things should be bonded or not
3) Adding a dubious "rebond" method which is called to create inter fragments bonds before assembling the final fragment.

Here are the results which are OK but not perfect:

| Name | OPSIN Current | OPSIN Patch (forceCovalent=false) | OPSIN Patch (forceCovalent=true) |
| --- | --- | --- | --- |
| `lithio acetate` | `C(C)(=O)O[Li]` | `C(C)(=O)[O-].[Li+]` | `C(C)(=O)O[Li]` |
| `lithium acetate` | `C(C)(=O)[O-].[Li+]` | `C(C)(=O)[O-].[Li+]` | `C(C)(=O)O[Li]` |
| `lithium(+1) acetate` | `C(C)(=O)[O-].[Li+]` | `C(C)(=O)[O-].[Li+]` | `C(C)(=O)O[Li]` |
| `trimethylmethyl acetate` | `C(C)(=O)OC(C)(C)C` | `C(C)(=O)OC(C)(C)C` | `C(C)(=O)OC(C)(C)C` |
| `trimethylcarbon acetate` | `C(C)(=O)[O-].C[C+](C)C` | `C(C)(=O)OC(C)(C)C` | `C(C)(=O)OC(C)(C)C` |
| `acetate carbon` | `[C+4].C(C)(=O)[O-].C(C)(=O)[O-].C(C)(=O)[O-].C(C)(=O)[O-]` | `C(OC(C)=O)(OC(C)=O)(OC(C)=O)OC(C)=O` | `C(OC(C)=O)(OC(C)=O)(OC(C)=O)OC(C)=O` |
| `calcium oxide` | `[O-2].[Ca+2]` | `[O-2].[Ca+2]` | `[Ca]=O` |
| `calcium acetate` | `C(C)(=O)[O-].[Ca+2].C(C)(=O)[O-]` | `C(C)(=O)[O-].[Ca+2].C(C)(=O)[O-]` | `C(C)(=O)O[Ca]OC(C)=O` |
| `calcium(I) acetate` | `C(C)(=O)[O-].[Ca+]` | `C(C)(=O)[O-].[Ca+]` | `C(C)(=O)O[Ca]` |
| `lithium fulminate` | `[O-][N+]#[C-].[Li+]` | `[O-][N+]#[C-].[Li+]` | `[Li]O[N+]#[C-]` |
| `calcium fulminate` | `[O-][N+]#[C-].[Ca+2].[O-][N+]#[C-]` | `[O-][N+]#[C-].[Ca+2].[O-][N+]#[C-]` | `[Ca](O[N+]#[C-])O[N+]#[C-]` |
| `mercury(II) fulminate` | `[Hg](O[N+]#[C-])O[N+]#[C-]` | `[Hg](O[N+]#[C-])O[N+]#[C-]` | `[Hg](O[N+]#[C-])O[N+]#[C-]` |
| `fulminate mercury(II)` | `[Hg+2].[O-][N+]#[C-].[O-][N+]#[C-]` | `[Hg+2].[O-][N+]#[C-].[O-][N+]#[C-]` | `[Hg+2].[O-][N+]#[C-].[O-][N+]#[C-]` |
| `carbon fulminate` | `C(O[N+]#[C-])(O[N+]#[C-])(O[N+]#[C-])O[N+]#[C-]` | `C(O[N+]#[C-])(O[N+]#[C-])(O[N+]#[C-])O[N+]#[C-]` | `C(O[N+]#[C-])(O[N+]#[C-])(O[N+]#[C-])O[N+]#[C-]` |
| `pyridinium acetate` | `C(C)(=O)[O-].[NH+]1=CC=CC=C1` | `C(C)(=O)[O-].[NH+]1=CC=CC=C1` | `C(C)(=O)[O-].[NH+]1=CC=CC=C1` |
| `calcium pyrrolide` | `[N-]1C=CC=C1.[Ca+2].[N-]1C=CC=C1` | `[N-]1C=CC=C1.[Ca+2].[N-]1C=CC=C1` | `N1(C=CC=C1)[Ca]N1C=CC=C1` |
| `calcium benzoate` | `C(C1=CC=CC=C1)(=O)[O-].[Ca+2].C(C1=CC=CC=C1)(=O)[O-]` | `C(C1=CC=CC=C1)(=O)[O-].[Ca+2].C(C1=CC=CC=C1)(=O)[O-]` | `C(C1=CC=CC=C1)(=O)O[Ca]OC(C1=CC=CC=C1)=O` |
| `calcium benzothioate` | `C(C1=CC=CC=C1)([O-])=S.[Ca+2].C(C1=CC=CC=C1)([O-])=S` | `C(C1=CC=CC=C1)([O-])=S.[Ca+2].C(C1=CC=CC=C1)([O-])=S` | `C(C1=CC=CC=C1)(O[Ca]OC(C1=CC=CC=C1)=S)=S` |
| `methyl nitrate` | `[N+](=O)(OC)[O-]` | `[N+](=O)(OC)[O-]` | `[N+](=O)(OC)[O-]` |
| `lithium nitrate` | `[N+](=O)([O-])[O-].[Li+]` | `[N+](=O)([O-])[O-].[Li+]` | `[N+](=O)([O-])[O-].[Li+]` |


I think a better approach is the ester word rule should have something similar to the oxide/additionCompound. However I'm not 100% sure on all the mechanisms.

I "think" I need to add this ``wordRules.xml``: 

```
	<wordRule name="ester" type="full">
		<word type="substituent" />
		<word type="full" endsWith="ateGroup"/>
	</wordRule>

+++	<wordRule name="ester" type="full">
+++		<word type="full" endsWithGroupType="elementaryAtom" />
+++		<word type="full" endsWith="ateGroup"/>
+++	</wordRule>
```

and then a minor tweak to ``WordRules.java``: 

```
	case additionCompound:
        case oxide:
+++     case ester:
+++        // change to getChemElFromWordWithFunctionalGroup
```

but then I get stuck in the ``buildEster()`` as there are (rightly) lots of guards in place to check for out atoms etc. Having an elementary atom instead of a substituent completely won't work - I could detect this and have dedicate logic but am curious on your thoughts. 

Hopefully you think with a bit of work this would be a useful change, certainly being more consistent and then being able to force covalent makes sense for some use cases.