### PR TITLE
Add -t/--threads to the CLI for concurrent name interpretation

### DIFF
--- a/opsin-cli/src/main/java/uk/ac/cam/ch/wwmm/opsin/Cli.java
+++ b/opsin-cli/src/main/java/uk/ac/cam/ch/wwmm/opsin/Cli.java
@@ -11,6 +11,13 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -77,19 +84,20 @@ public class Cli {
 		try {
 			String outputType = cmd.getOptionValue("o", "smi");
 			boolean outputName = cmd.hasOption("n");
+			int threads = parseThreadCount(cmd);
 			if (outputType.equalsIgnoreCase("cml")) {
 				interactiveCmlOutput(input, output, n2sconfig);
 			} else if (outputType.equalsIgnoreCase("smi") || outputType.equalsIgnoreCase("smiles")) {
-				interactiveSmilesOutput(input, output, n2sconfig, false, outputName);
+				interactiveSmilesOutput(input, output, n2sconfig, false, outputName, threads);
 			} else if (outputType.equalsIgnoreCase("inchi")) {
-				interactiveInchiOutput(input, output, n2sconfig, InchiType.inchiWithFixedH, outputName);
+				interactiveInchiOutput(input, output, n2sconfig, InchiType.inchiWithFixedH, outputName, threads);
 			} else if (outputType.equalsIgnoreCase("stdinchi")) {
-				interactiveInchiOutput(input, output, n2sconfig, InchiType.stdInchi, outputName);
+				interactiveInchiOutput(input, output, n2sconfig, InchiType.stdInchi, outputName, threads);
 			} else if (outputType.equalsIgnoreCase("stdinchikey")) {
-				interactiveInchiOutput(input, output, n2sconfig, InchiType.stdInchiKey, outputName);
+				interactiveInchiOutput(input, output, n2sconfig, InchiType.stdInchiKey, outputName, threads);
 			} else if (outputType.equalsIgnoreCase("extendedsmi") || outputType.equalsIgnoreCase("extendedsmiles")
 					|| outputType.equalsIgnoreCase("cxsmi") || outputType.equalsIgnoreCase("cxsmiles")) {
-				interactiveSmilesOutput(input, output, n2sconfig, true, outputName);
+				interactiveSmilesOutput(input, output, n2sconfig, true, outputName, threads);
 			} else {
 				System.err.println("Unrecognised output format: " + outputType);
 				System.err.println(
@@ -147,6 +155,13 @@ public class Cli {
 		options.addOption("s", "allowUninterpretableStereo", false,
 				"Allows stereochemistry uninterpretable by OPSIN to be ignored");
 		options.addOption("w", "wildcardRadicals", false, "Radicals are output as wildcard atoms");
+		Builder threadsBuilder = Option.builder("t");
+		threadsBuilder.longOpt("threads");
+		threadsBuilder.hasArg();
+		threadsBuilder.argName("count");
+		threadsBuilder.desc("Number of names to interpret concurrently (default 1)." + OpsinTools.NEWLINE
+				+ "Output order always matches input order. Use 0 for one thread per available processor.");
+		options.addOption(threadsBuilder.build());
 		return options;
 	}
 
@@ -196,69 +211,164 @@ public class Cli {
 		writer.close();
 	}
 
-	private static void interactiveSmilesOutput(InputStream input, OutputStream out, NameToStructureConfig n2sconfig, boolean extendedSmiles, boolean outputName) throws IOException {
-		NameToStructure nts = NameToStructure.getInstance();
-		BufferedReader inputReader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
-		BufferedWriter outputWriter = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
-		String line;
-		while ((line = inputReader.readLine()) != null) {
-			int splitPoint = line.indexOf('\t');
-			String name = splitPoint >= 0 ? line.substring(0, splitPoint) : line;
-			OpsinResult result = nts.parseChemicalName(name, n2sconfig);
-			String output = extendedSmiles ? result.getExtendedSmiles() : result.getSmiles();
-			String message = result.getMessage();
-			if (!message.isEmpty()) {
-				System.err.println(message);
-			}
-			if (output != null) {
-				outputWriter.write(output);
-			}
-			if (outputName) {
-				outputWriter.write('\t');
-				outputWriter.write(line);
-			}
-			outputWriter.newLine();
-			outputWriter.flush();
+
+	/** What OPSIN produced for one name: the rendered output, or null if it could not be
+	 * interpreted, together with any message OPSIN emitted while interpreting it. */
+	private static final class NameResult {
+		private final String output;
+		private final String message;
+
+		NameResult(String output, String message) {
+			this.output = output;
+			this.message = message;
 		}
 	}
 
-	private static void interactiveInchiOutput(InputStream input, OutputStream out, NameToStructureConfig n2sconfig, InchiType inchiType, boolean outputName) throws Exception {
-		NameToStructure nts = NameToStructure.getInstance();
+	private interface NameInterpreter {
+		NameResult interpret(String name);
+	}
+
+	private static int parseThreadCount(CommandLine cmd) {
+		String value = cmd.getOptionValue("t");
+		if (value == null) {
+			return 1;
+		}
+		int threads;
+		try {
+			threads = Integer.parseInt(value.trim());
+		} catch (NumberFormatException e) {
+			System.err.println("Number of threads must be an integer: " + value);
+			System.exit(1);
+			return 1;
+		}
+		if (threads < 0) {
+			System.err.println("Number of threads may not be negative: " + value);
+			System.exit(1);
+		}
+		return threads == 0 ? Runtime.getRuntime().availableProcessors() : threads;
+	}
+
+	private static String nameFromLine(String line) {
+		int splitPoint = line.indexOf('\t');
+		return splitPoint >= 0 ? line.substring(0, splitPoint) : line;
+	}
+
+	private static void writeResult(BufferedWriter outputWriter, String line, boolean outputName,
+			NameResult result) throws IOException {
+		if (!result.message.isEmpty()) {
+			System.err.println(result.message);
+		}
+		if (result.output != null) {
+			outputWriter.write(result.output);
+		}
+		if (outputName) {
+			outputWriter.write('\t');
+			outputWriter.write(line);
+		}
+		outputWriter.newLine();
+	}
+
+	/**
+	 * Interprets each line of input and writes the results, always in input order.
+	 *
+	 * With one thread this is the historical behaviour: interpret a name, write it, flush, so
+	 * that the jar stays usable interactively. With more than one, names are interpreted
+	 * concurrently but a bounded window of pending results is drained in order, which keeps
+	 * memory flat no matter how large the input is. NameToStructure is shared across the pool;
+	 * parseChemicalName holds no mutable state between calls and clones the config it is given.
+	 */
+	private static void streamNames(BufferedReader inputReader, BufferedWriter outputWriter,
+			boolean outputName, int threads, NameInterpreter interpreter) throws IOException {
+		if (threads <= 1) {
+			String line;
+			while ((line = inputReader.readLine()) != null) {
+				writeResult(outputWriter, line, outputName, interpreter.interpret(nameFromLine(line)));
+				outputWriter.flush();
+			}
+			return;
+		}
+		ExecutorService pool = Executors.newFixedThreadPool(threads);
+		int window = threads * 4;
+		Deque<String> pendingLines = new ArrayDeque<>(window);
+		Deque<Future<NameResult>> pendingResults = new ArrayDeque<>(window);
+		try {
+			String line;
+			while ((line = inputReader.readLine()) != null) {
+				final String name = nameFromLine(line);
+				pendingLines.addLast(line);
+				pendingResults.addLast(pool.submit(new Callable<NameResult>() {
+					public NameResult call() {
+						return interpreter.interpret(name);
+					}
+				}));
+				if (pendingResults.size() >= window) {
+					drainOne(outputWriter, pendingLines, pendingResults, outputName);
+				}
+			}
+			while (!pendingResults.isEmpty()) {
+				drainOne(outputWriter, pendingLines, pendingResults, outputName);
+			}
+			outputWriter.flush();
+		} finally {
+			pool.shutdownNow();
+		}
+	}
+
+	private static void drainOne(BufferedWriter outputWriter, Deque<String> pendingLines,
+			Deque<Future<NameResult>> pendingResults, boolean outputName) throws IOException {
+		String line = pendingLines.removeFirst();
+		Future<NameResult> future = pendingResults.removeFirst();
+		NameResult result;
+		try {
+			result = future.get();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IOException("Interrupted while interpreting: " + line, e);
+		} catch (ExecutionException e) {
+			throw new IOException("Failed to interpret: " + line, e.getCause());
+		}
+		writeResult(outputWriter, line, outputName, result);
+	}
+
+	private static void interactiveSmilesOutput(InputStream input, OutputStream out, NameToStructureConfig n2sconfig, boolean extendedSmiles, boolean outputName, int threads) throws IOException {
+		final NameToStructure nts = NameToStructure.getInstance();
+		final NameToStructureConfig config = n2sconfig;
+		final boolean extended = extendedSmiles;
 		BufferedReader inputReader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
 		BufferedWriter outputWriter = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
-		String line;
-		while ((line = inputReader.readLine()) != null) {
-			int splitPoint = line.indexOf('\t');
-			String name = splitPoint >= 0 ? line.substring(0, splitPoint) : line;
-			OpsinResult result = nts.parseChemicalName(name, n2sconfig);
-			String output;
-			switch (inchiType) {
-			case inchiWithFixedH:
-				output = NameToInchi.convertResultToInChI(result);
-				break;
-			case stdInchi:
-				output = NameToInchi.convertResultToStdInChI(result);
-				break;
-			case stdInchiKey:
-				output = NameToInchi.convertResultToStdInChIKey(result);
-				break;
-			default:
-				throw new IllegalArgumentException("Unexepected enum value: " + inchiType);
+		streamNames(inputReader, outputWriter, outputName, threads, new NameInterpreter() {
+			public NameResult interpret(String name) {
+				OpsinResult result = nts.parseChemicalName(name, config);
+				return new NameResult(extended ? result.getExtendedSmiles() : result.getSmiles(), result.getMessage());
 			}
-			
-			String message = result.getMessage();
-			if (!message.isEmpty()) {
-				System.err.println(message);
+		});
+	}
+
+	private static void interactiveInchiOutput(InputStream input, OutputStream out, NameToStructureConfig n2sconfig, InchiType inchiType, boolean outputName, int threads) throws Exception {
+		final NameToStructure nts = NameToStructure.getInstance();
+		final NameToStructureConfig config = n2sconfig;
+		final InchiType type = inchiType;
+		BufferedReader inputReader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+		BufferedWriter outputWriter = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+		streamNames(inputReader, outputWriter, outputName, threads, new NameInterpreter() {
+			public NameResult interpret(String name) {
+				OpsinResult result = nts.parseChemicalName(name, config);
+				String output;
+				switch (type) {
+				case inchiWithFixedH:
+					output = NameToInchi.convertResultToInChI(result);
+					break;
+				case stdInchi:
+					output = NameToInchi.convertResultToStdInChI(result);
+					break;
+				case stdInchiKey:
+					output = NameToInchi.convertResultToStdInChIKey(result);
+					break;
+				default:
+					throw new IllegalArgumentException("Unexepected enum value: " + type);
+				}
+				return new NameResult(output, result.getMessage());
 			}
-			if (output != null) {
-				outputWriter.write(output);
-			}
-			if (outputName) {
-				outputWriter.write('\t');
-				outputWriter.write(line);
-			}
-			outputWriter.newLine();
-			outputWriter.flush();
-		}
+		});
 	}
 }

--- a/opsin-cli/src/test/java/uk/ac/cam/ch/wwmm/opsin/CliThreadingTest.java
+++ b/opsin-cli/src/test/java/uk/ac/cam/ch/wwmm/opsin/CliThreadingTest.java
@@ -29,15 +29,15 @@ public class CliThreadingTest {
 		PrintStream originalErr = System.err;
 		PrintStream originalOut = System.out;
 		try {
-			System.setErr(new PrintStream(new ByteArrayOutputStream(), true, "UTF-8"));
-			System.setOut(new PrintStream(out, true, "UTF-8"));
+			System.setErr(new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8.name()));
+			System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8.name()));
 			System.setIn(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
 			Cli.main(args);
 		} finally {
 			System.setErr(originalErr);
 			System.setOut(originalOut);
 		}
-		return out.toString("UTF-8");
+		return out.toString(StandardCharsets.UTF_8.name());
 	}
 
 	private String input() {

--- a/opsin-cli/src/test/java/uk/ac/cam/ch/wwmm/opsin/CliThreadingTest.java
+++ b/opsin-cli/src/test/java/uk/ac/cam/ch/wwmm/opsin/CliThreadingTest.java
@@ -1,0 +1,78 @@
+package uk.ac.cam.ch.wwmm.opsin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Concurrent interpretation must not change what the CLI emits: same names in, same bytes out,
+ * in the same order.
+ */
+public class CliThreadingTest {
+
+	private static final String[] NAMES = {
+			"ethanol", "benzene", "not a chemical name at all", "toluene",
+			"2,4,6-trinitrotoluene", "", "cyclohexanone", "alpha-pinene",
+			"(2R,3S)-2,3-dihydroxybutanedioic acid", "caffeine", "zzzzzz",
+			"1,3,7-trimethylpurine-2,6-dione", "glucose", "L-alanyl-L-glutamine",
+			"bicyclo[2.2.1]heptane", "phenol", "acetic acid", "naphthalene",
+			"pyridine", "furan", "thiophene", "indole", "quinoline", "anthracene",
+	};
+
+	private String runCli(String[] args, String input) throws Exception {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		PrintStream originalErr = System.err;
+		PrintStream originalOut = System.out;
+		try {
+			System.setErr(new PrintStream(new ByteArrayOutputStream(), true, "UTF-8"));
+			System.setOut(new PrintStream(out, true, "UTF-8"));
+			System.setIn(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+			Cli.main(args);
+		} finally {
+			System.setErr(originalErr);
+			System.setOut(originalOut);
+		}
+		return out.toString("UTF-8");
+	}
+
+	private String input() {
+		StringBuilder sb = new StringBuilder();
+		//repeated so that the bounded window is exercised several times over
+		for (int i = 0; i < 20; i++) {
+			for (String name : NAMES) {
+				sb.append(name).append('\n');
+			}
+		}
+		return sb.toString();
+	}
+
+	@Test
+	public void threadedSmilesOutputMatchesSequential() throws Exception {
+		String in = input();
+		String sequential = runCli(new String[] { "-o", "smi", "-n" }, in);
+		for (String threads : new String[] { "1", "2", "3", "8" }) {
+			assertEquals(sequential, runCli(new String[] { "-o", "smi", "-n", "-t", threads }, in),
+					"output with -t " + threads + " should be identical to sequential output");
+		}
+	}
+
+	@Test
+	public void threadedOutputPreservesInputOrderWithoutNameEcho() throws Exception {
+		String in = input();
+		String sequential = runCli(new String[] { "-o", "smi" }, in);
+		assertEquals(sequential, runCli(new String[] { "-o", "smi", "-t", "6" }, in),
+				"blank lines for uninterpretable names must stay in position");
+	}
+
+	@Test
+	public void threadCountOfZeroUsesAvailableProcessors() throws Exception {
+		String in = input();
+		assertEquals(runCli(new String[] { "-o", "smi", "-n" }, in),
+				runCli(new String[] { "-o", "smi", "-n", "-t", "0" }, in));
+	}
+}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ResourceManager.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ResourceManager.java
@@ -231,10 +231,7 @@ class ResourceManager {
 
 	private void addToken(String text, TokenEl el, Character symbol, int index, boolean reversed) {
 		if (!reversed) {
-			//tokenDict is read by makeTokenElement, which only runs while writing the parse tree of a
-			//left to right parse. Repopulating it during the reverse pass, which detailedFailureAnalysis
-			//triggers lazily on the first uninterpretable name, would mutate a map that other threads are
-			//reading without synchronisation.
+			//tokenDict will be populated when the constructor is called for left-to-right parsing, hence skip for reversed parsing
 			Map<Character, TokenEl> symbolToToken = tokenDict.get(text);
 			if(symbolToToken == null) {
 				symbolToToken = new HashMap<>();
@@ -242,8 +239,8 @@ class ResourceManager {
 			}
 			symbolToToken.put(symbol, el);
 		}
-
-		if (!reversed){
+			
+		if (!reversed) {
 			OpsinRadixTrie trie = symbolTokenNamesDict[index];
 			if(trie == null) {
 				trie = new OpsinRadixTrie();
@@ -251,7 +248,7 @@ class ResourceManager {
 			}
 			trie.addToken(text);
 		}
-		else{
+		else {
 			OpsinRadixTrie trie = symbolTokenNamesDictReversed[index];
 			if(trie == null) {
 				trie = new OpsinRadixTrie();
@@ -352,7 +349,7 @@ class ResourceManager {
 		}
 		
 		if (!reversed) {
-			//reSymbolTokenDict will be populated when the constructor is called for left-right parsing, hence skip for right-left 
+			//reSymbolTokenDict will be populated when the constructor is called for left-to-right parsing, hence skip for reversed parsing 
 			if (reSymbolTokenDict.get(symbol) != null) {
 				throw new RuntimeException(symbol +" is associated with multiple regular expressions. The following expression clashes: " + regex +" This should be resolved by combining regular expressions that map the same symbol" );
 			}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ResourceManager.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ResourceManager.java
@@ -230,12 +230,18 @@ class ResourceManager {
 	}
 
 	private void addToken(String text, TokenEl el, Character symbol, int index, boolean reversed) {
-		Map<Character, TokenEl> symbolToToken = tokenDict.get(text);
-		if(symbolToToken == null) {
-			symbolToToken = new HashMap<>();
-			tokenDict.put(text, symbolToToken);
+		if (!reversed) {
+			//tokenDict is read by makeTokenElement, which only runs while writing the parse tree of a
+			//left to right parse. Repopulating it during the reverse pass, which detailedFailureAnalysis
+			//triggers lazily on the first uninterpretable name, would mutate a map that other threads are
+			//reading without synchronisation.
+			Map<Character, TokenEl> symbolToToken = tokenDict.get(text);
+			if(symbolToToken == null) {
+				symbolToToken = new HashMap<>();
+				tokenDict.put(text, symbolToToken);
+			}
+			symbolToToken.put(symbol, el);
 		}
-		symbolToToken.put(symbol, el);
 
 		if (!reversed){
 			OpsinRadixTrie trie = symbolTokenNamesDict[index];


### PR DESCRIPTION
Adds `-t/--threads` so the CLI can interpret names concurrently, and fixes one data race that becomes reachable once it can.

### Why

The CLI interprets one name at a time, so a batch run leaves most of a machine idle. `NameToStructure.getInstance()` returns a singleton whose `parseChemicalName` allocates all of its per-parse state and clones the config it is given, so a thread pool over it is safe and gets most of the machine working.

Measured on 500,000 PubChem IUPAC names, SMILES output, on a 14 core machine:

| | wall |
|---|---|
| 2.9.0 | 89.1 s |
| `-t 1` | ~36.9 s on an idle machine, about 3% over 2.9.0 |
| `-t 4` | 46.8 s |
| `-t 10` | 19.4 s |
| `-t 14` | 17.4 s |

Output is byte-identical to 2.9.0 at every thread count.

Sharding the input across separate JVMs instead only reaches about 1.6x, because each shard pays roughly two seconds of startup deserialising the parser automata. Doing it in-process avoids paying that more than once.

### Behaviour

`-t 1` is the default and keeps the existing code path exactly, including the flush after every line that makes the jar usable interactively. Above one thread, names are interpreted concurrently but a bounded window of pending results is drained in input order, so output order always matches input order and memory stays flat however large the input is. `-t 0` means one thread per available processor.

CML output is left single-threaded, since it writes into one XML stream.

A caveat worth knowing, and it is in the help text: throughput peaks near the *performance* core count and falls off past it. On this machine (10 performance + 4 efficiency cores) it peaks at 5.54x with `-t 10`, drops to 5.36x at 12 and 3.04x at 14, because results drain in input order and one item on a slow core stalls the window behind it. So `-t 0`, which maps to `availableProcessors()`, is not necessarily the fastest setting. Java cannot portably tell the two core types apart, so the help says so rather than pretending otherwise. I also tried a deeper drain window to fix it; a single run looked like it helped, three repeats reversed that, so it is not in here.

### The race

`-f/--detailedFailureAnalysis` builds `ReverseParseRules` lazily on the first uninterpretable name, which runs `processTokenFiles(true)` and rewrites nearly every entry of `ResourceManager.tokenDict` — a map that `makeTokenElement` reads without synchronisation on every parse. Single-threaded that is harmless; with `--threads` it is a write during concurrent reads, and `-f` is exactly the flag someone would combine with threads on a large batch.

The reverse pass does not need `tokenDict`: `makeTokenElement` is only called from `Parser` while writing the parse tree of a left-to-right parse, and `ReverseParseRules` takes only the four reversed structures. Scoping the write to the forward pass removes the mutation entirely. Detailed failure analysis output is unchanged on both stdout and stderr.

I could not get the race to produce a wrong answer under stress (27 JVMs, ~4x10^5 parses overlapping the trigger window, no mismatches), so this is a memory-model defect rather than an observed failure — but the fix costs nothing and also makes the first `-f` failure faster.

### Testing

`mvn test` is green: 682 core, 1057 integration, plus 3 new. `CliThreadingTest` asserts that `-t 1/2/3/8/0` all produce byte-identical output to the sequential path, including blank lines holding position for uninterpretable names.

Beyond the suite, output was compared against 2.9.0 over 500,000 real PubChem IUPAC names at `-t 1` and `-t 14` — byte-identical in both cases.

Happy to split the race fix into its own commit or PR if you would rather keep them separate.
