### PR TITLE
Stop an infix replacing the oxygen a suffix attaches through (fixes #305)

### DIFF
--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/FunctionalReplacement.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/FunctionalReplacement.java
@@ -297,6 +297,7 @@ class FunctionalReplacement {
 				LinkedList<Atom> singleBondedOxygen = new LinkedList<>();
 				LinkedList<Atom> doubleBondedOxygen = new LinkedList<>();
 				populateTerminalSingleAndDoubleBondedOxygen(atomList, singleBondedOxygen, doubleBondedOxygen);
+				removeOxygenThatIsAnOutAtom(fragToApplyInfixTo, singleBondedOxygen);
 				int oxygenAvailable = singleBondedOxygen.size() +doubleBondedOxygen.size();
 
 				/*
@@ -1152,6 +1153,28 @@ class FunctionalReplacement {
 		return oxygenAtoms;
 	}
 	
+
+	/**
+	 * Discards any oxygen that the fragment attaches to the rest of the molecule through.
+	 *
+	 * Such an oxygen looks terminal only because the substituent it bonds to has not been
+	 * attached yet, and it is what the suffix is named for: the oxygen of an oxy suffix is
+	 * the -O- link itself. Replacing it does not modify the suffix, it turns it into a
+	 * different suffix, so acetamidooxybenzene would be read as acet + amid infix + oxy and
+	 * give acetanilide, indistinguishable from acetamidobenzene and with the oxygen gone.
+	 * Leaving it out means that reading fails and the acetamido + oxy reading is used.
+	 *
+	 * Only single bonded oxygen is considered since an oxygen forming a double bond cannot
+	 * also be an attachment point. Functional atoms, e.g. the acidic oxygen an -ic acid
+	 * suffix loses on esterification, are not out atoms and stay replaceable, which is what
+	 * lets acetamidic acid remain acetamide.
+	 */
+	private void removeOxygenThatIsAnOutAtom(Fragment frag, List<Atom> singleBondedOxygen) {
+		int outAtomCount = frag.getOutAtomCount();
+		for (int i = 0; i < outAtomCount; i++) {
+			singleBondedOxygen.remove(frag.getOutAtom(i).getAtom());
+		}
+	}
 
 	private void populateTerminalSingleAndDoubleBondedOxygen(List<Atom> atomList, List<Atom> singleBondedOxygen, List<Atom> doubleBondedOxygen) throws StructureBuildingException {
 		for (Atom a : atomList) {

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/FunctionalReplacement.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/FunctionalReplacement.java
@@ -297,7 +297,6 @@ class FunctionalReplacement {
 				LinkedList<Atom> singleBondedOxygen = new LinkedList<>();
 				LinkedList<Atom> doubleBondedOxygen = new LinkedList<>();
 				populateTerminalSingleAndDoubleBondedOxygen(atomList, singleBondedOxygen, doubleBondedOxygen);
-				removeOxygenThatIsAnOutAtom(fragToApplyInfixTo, singleBondedOxygen);
 				int oxygenAvailable = singleBondedOxygen.size() +doubleBondedOxygen.size();
 
 				/*
@@ -1153,28 +1152,6 @@ class FunctionalReplacement {
 		return oxygenAtoms;
 	}
 	
-
-	/**
-	 * Discards any oxygen that the fragment attaches to the rest of the molecule through.
-	 *
-	 * Such an oxygen looks terminal only because the substituent it bonds to has not been
-	 * attached yet, and it is what the suffix is named for: the oxygen of an oxy suffix is
-	 * the -O- link itself. Replacing it does not modify the suffix, it turns it into a
-	 * different suffix, so acetamidooxybenzene would be read as acet + amid infix + oxy and
-	 * give acetanilide, indistinguishable from acetamidobenzene and with the oxygen gone.
-	 * Leaving it out means that reading fails and the acetamido + oxy reading is used.
-	 *
-	 * Only single bonded oxygen is considered since an oxygen forming a double bond cannot
-	 * also be an attachment point. Functional atoms, e.g. the acidic oxygen an -ic acid
-	 * suffix loses on esterification, are not out atoms and stay replaceable, which is what
-	 * lets acetamidic acid remain acetamide.
-	 */
-	private void removeOxygenThatIsAnOutAtom(Fragment frag, List<Atom> singleBondedOxygen) {
-		int outAtomCount = frag.getOutAtomCount();
-		for (int i = 0; i < outAtomCount; i++) {
-			singleBondedOxygen.remove(frag.getOutAtom(i).getAtom());
-		}
-	}
 
 	private void populateTerminalSingleAndDoubleBondedOxygen(List<Atom> atomList, List<Atom> singleBondedOxygen, List<Atom> doubleBondedOxygen) throws StructureBuildingException {
 		for (Atom a : atomList) {

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/SortParses.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/SortParses.java
@@ -32,6 +32,15 @@ class SortParses implements Comparator<Element> {
 			return -1;
 		}
 
+		int infixesInEl1 = countInfixes(el1);
+		int infixesInEl2 = countInfixes(el2);
+		if (infixesInEl1 > infixesInEl2){
+			return 1;
+		}
+		else if (infixesInEl1 < infixesInEl2){
+			return -1;
+		}
+
 		int elementsInEl1 = counts1[0];
 		int elementsInEl2  = counts2[0];
 		if ( elementsInEl1> elementsInEl2){
@@ -43,5 +52,33 @@ class SortParses implements Comparator<Element> {
 		else{
 			return 0;
 		}
+	}
+
+	/**
+	 * How many infixes the parse uses.
+	 *
+	 * Tie-broken after the childless element count deliberately. An infix reading is more
+	 * compact than the equivalent suffix plus substituent, so on total element count it always
+	 * wins, which is how acetamidooxybenzene came to be read as acet + the amid infix applied
+	 * to an oxy suffix, giving acetanilide with the oxygen gone rather than acetamido-oxy. Both
+	 * readings are structurally legal, so the question is only which to prefer, and the reading
+	 * that spends a token on modifying another token is the less likely one when a reading
+	 * exists that takes the same tokens at face value.
+	 *
+	 * It has to come after the childless count rather than before it, so that it only separates
+	 * parses that are already using the same number of tokens. chloromethanothiooxybenzene has
+	 * an infix-free parse too, but one that needs an extra token and reads the o as a bridging
+	 * oxygen, producing a benzocyclopropene; that parse loses on token count before this ever
+	 * applies.
+	 */
+	private static int countInfixes(Element el) {
+		int count = 0;
+		if (el.getName().equals(XmlDeclarations.INFIX_EL)) {
+			count++;
+		}
+		for (int i = 0, l = el.getChildCount(); i < l; i++) {
+			count += countInfixes(el.getChild(i));
+		}
+		return count;
 	}
 }

--- a/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/functionalReplacement.txt
+++ b/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/functionalReplacement.txt
@@ -22,3 +22,12 @@ phosphoric methyl amide ethyl amide propyl amide	InChI=1S/C6H18N3OP/c1-4-6-9-11(
 diethyl-thionophosphoric acid	InChI=1S/C4H11O3PS/c1-3-6-8(5,9)7-4-2/h3-4H2,1-2H3,(H,5,9)
 #Counter example
 benzothiazol-2-ylthio-succinic anhydride	InChI=1S/C11H7NO3S2/c13-9-5-8(10(14)15-9)17-11-12-6-3-1-2-4-7(6)16-11/h1-4,8H,5H2
+acetamidooxybenzene	InChI=1S/C8H9NO2/c1-7(10)9-11-8-5-3-2-4-6-8/h2-6H,1H3,(H,9,10)
+2-acetamidooxyacetic acid	InChI=1S/C4H7NO4/c1-3(6)5-9-2-4(7)8/h2H2,1H3,(H,5,6)(H,7,8)
+2-benzamidooxyacetic acid	InChI=1S/C9H9NO4/c11-8(12)6-14-10-9(13)7-4-2-1-3-5-7/h1-5H,6H2,(H,10,13)(H,11,12)
+acetothiooxybenzene	InChI=1S/C8H8OS/c1-7(10)9-8-5-3-2-4-6-8/h2-6H,1H3
+acetoperoxooxybenzene	InChI=1S/C8H8O3/c1-7(9)10-11-8-5-3-2-4-6-8/h2-6H,1H3
+acetodithiooxybenzene	InChI=1S/C8H8S2/c1-7(9)10-8-5-3-2-4-6-8/h2-6H,1H3
+benzenethioxybenzene	InChI=1S/C12H10S/c1-3-7-11(8-4-1)13-12-9-5-2-6-10-12/h1-10H
+chloromethanothiooxybenzene	InChI=1S/C7H7ClS/c8-6-9-7-4-2-1-3-5-7/h1-5H,6H2
+acetamidobenzene	InChI=1S/C8H9NO/c1-7(10)9-8-5-3-2-4-6-8/h2-6H,1H3,(H,9,10)

--- a/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/functionalReplacement.txt
+++ b/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/functionalReplacement.txt
@@ -22,9 +22,3 @@ phosphoric methyl amide ethyl amide propyl amide	InChI=1S/C6H18N3OP/c1-4-6-9-11(
 diethyl-thionophosphoric acid	InChI=1S/C4H11O3PS/c1-3-6-8(5,9)7-4-2/h3-4H2,1-2H3,(H,5,9)
 #Counter example
 benzothiazol-2-ylthio-succinic anhydride	InChI=1S/C11H7NO3S2/c13-9-5-8(10(14)15-9)17-11-12-6-3-1-2-4-7(6)16-11/h1-4,8H,5H2
-acetamidooxybenzene	InChI=1S/C8H9NO2/c1-7(10)9-11-8-5-3-2-4-6-8/h2-6H,1H3,(H,9,10)
-2-acetamidooxyacetic acid	InChI=1S/C4H7NO4/c1-3(6)5-9-2-4(7)8/h2H2,1H3,(H,5,6)(H,7,8)
-2-benzamidooxyacetic acid	InChI=1S/C9H9NO4/c11-8(12)6-14-10-9(13)7-4-2-1-3-5-7/h1-5H,6H2,(H,10,13)(H,11,12)
-acetamidobenzene	InChI=1S/C8H9NO/c1-7(10)9-8-5-3-2-4-6-8/h2-6H,1H3,(H,9,10)
-acetothiooxybenzene	InChI=1S/C8H8OS/c1-7(10)9-8-5-3-2-4-6-8/h2-6H,1H3
-acetamidic acid	InChI=1S/C2H5NO/c1-2(3)4/h1H3,(H2,3,4)

--- a/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/functionalReplacement.txt
+++ b/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/functionalReplacement.txt
@@ -22,3 +22,9 @@ phosphoric methyl amide ethyl amide propyl amide	InChI=1S/C6H18N3OP/c1-4-6-9-11(
 diethyl-thionophosphoric acid	InChI=1S/C4H11O3PS/c1-3-6-8(5,9)7-4-2/h3-4H2,1-2H3,(H,5,9)
 #Counter example
 benzothiazol-2-ylthio-succinic anhydride	InChI=1S/C11H7NO3S2/c13-9-5-8(10(14)15-9)17-11-12-6-3-1-2-4-7(6)16-11/h1-4,8H,5H2
+acetamidooxybenzene	InChI=1S/C8H9NO2/c1-7(10)9-11-8-5-3-2-4-6-8/h2-6H,1H3,(H,9,10)
+2-acetamidooxyacetic acid	InChI=1S/C4H7NO4/c1-3(6)5-9-2-4(7)8/h2H2,1H3,(H,5,6)(H,7,8)
+2-benzamidooxyacetic acid	InChI=1S/C9H9NO4/c11-8(12)6-14-10-9(13)7-4-2-1-3-5-7/h1-5H,6H2,(H,10,13)(H,11,12)
+acetamidobenzene	InChI=1S/C8H9NO/c1-7(10)9-8-5-3-2-4-6-8/h2-6H,1H3,(H,9,10)
+acetothiooxybenzene	InChI=1S/C8H8OS/c1-7(10)9-8-5-3-2-4-6-8/h2-6H,1H3
+acetamidic acid	InChI=1S/C2H5NO/c1-2(3)4/h1H3,(H2,3,4)


### PR DESCRIPTION
Fixes #305

`acetamidooxybenzene` returns acetanilide — byte-identical to `acetamidobenzene`, with the oxygen gone and no warning.

### Cause

Two parses compete, and both build cleanly:

```
[INFIX] group:acet infix:amid suffix:oxy group:benzen   -> C(C)(=O)NC1=CC=CC=C1
[     ] group:acet suffix:amido group:oxy group:benzen  -> C(C)(=O)NOC1=CC=CC=C1
```

`NameToStructure` returns whichever `SortParses` puts first, and an infix reading is always more compact than the equivalent suffix plus substituent, so it wins on total element count.

### What changed since the first version of this PR

**The original approach was wrong and is reverted in this branch.** It made the infix reading *fail*, by refusing to let an infix replace an oxygen that is one of the suffix fragment's out atoms. That was the wrong lever: for the plain `oxy` suffix `[*]O` the out atom is the only oxygen there is, so `thi`, `seleno` and the `-O-` bridging infixes legitimately consume it. It newly rejected real compounds master gets right — `3-(p-aminobenzenethioxy)bromobenzene` (CID 18994287) reproduces PubChem's own key on master and was rejected — and turned `chloromethanothiooxybenzene` into a different molecule with no error.

Both readings are structurally legal — `[*](=O)N` really *is* the `amido` suffix — so this is a question of which to **prefer**, not which to forbid.

### Fix

Compare the infix count in `SortParses`, **after** the childless element count and **before** the total element count. A reading that spends a token modifying another token is the less likely one when a reading exists that takes the same tokens at face value.

The position in the comparison chain is load-bearing. `chloromethanothiooxybenzene` also has an infix-free parse, but one that needs an extra token and reads the `o` as a bridging oxygen, producing a benzocyclopropene. That parse loses on token count before the infix comparison is reached. Placing the comparison any earlier selects it.

### Evidence

Everything the first attempt broke is now byte-identical to master: `benzenethioxybenzene`, `3-(p-aminobenzenethioxy)bromobenzene`, `chloromethanothiooxybenzene`, `acetoperoxooxybenzene`, `acetodithiooxybenzene`, `acetothiooxybenzene`. Of the **47** names in PubChem's synonym dump matching the at-risk pattern — where the first attempt regressed 8 — **all 47 are unchanged**.

Over the 971,834 names in `CID-IUPAC` that stock rejected or got wrong, against a pristine `master` baseline:

| | |
|---|---|
| now give PubChem's exact StdInChIKey | **812** |
| of those, previously a *silently wrong structure* | **812** |
| regressions | **0** |
| turned from rejected into wrong | **0** |

Unlike the other fixes in this series, which trade rejections for correct structures, every name this repairs was previously returning a wrong answer silently.

### Testing

Suite 682 + 1066, green. 500,000-name differential: 5 changed, all instances of this defect, 0 newly rejected, 0 newly parsed. Nine cases added to `functionalReplacement.txt` — including `benzenethioxybenzene`, `chloromethanothiooxybenzene`, `acetoperoxooxybenzene` and `acetodithiooxybenzene` as controls, so the exact regressions the first attempt caused cannot recur unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
