### PR TITLE
Add a peroxycyanate token so its esters and salts keep two oxygens (fixes #306)

### DIFF
--- a/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/functionalTerms.xml
+++ b/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/functionalTerms.xml
@@ -168,6 +168,11 @@ For these groups the charge on the first atom will be increased by 1 if they are
 		<token value="[N-]=C=[Se]">isoselenocyanate|isoselenocyanat</token>
 		<token value="[N-]=C=[Te]">isotellurocyanate|isotellurocyanat</token>
 		<token value="[N-]=C=S">isothiocyanate|isothiocyanat</token>
+		<!--peroxycyanic acid is N#C-O-OH, so its esters and salts carry two oxygens. Without this
+		token the name is read as the peroxy joiner applied to cyanate, which adds an -O-O- alongside
+		cyanate's own oxygen and yields three. The acid itself is built by functional replacement on
+		cyanic acid's functional oxygen and is unaffected.-->
+		<token value="[O-]OC#N">peroxycyanate|peroxycyanat</token>
 		<token value="[Se-]C#N">selenocyanate|selenocyanat</token>
 		<token value="[Se-][N+]#[C-]">selenofulminate|selenofulminat</token>
 		<token value="[Te-]C#N">tellurocyanate|tellurocyanat</token>

--- a/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/functionalTerms.xml
+++ b/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/functionalTerms.xml
@@ -168,10 +168,6 @@ For these groups the charge on the first atom will be increased by 1 if they are
 		<token value="[N-]=C=[Se]">isoselenocyanate|isoselenocyanat</token>
 		<token value="[N-]=C=[Te]">isotellurocyanate|isotellurocyanat</token>
 		<token value="[N-]=C=S">isothiocyanate|isothiocyanat</token>
-		<!--peroxycyanic acid is N#C-O-OH, so its esters and salts carry two oxygens. Without this
-		token the name is read as the peroxy joiner applied to cyanate, which adds an -O-O- alongside
-		cyanate's own oxygen and yields three. The acid itself is built by functional replacement on
-		cyanic acid's functional oxygen and is unaffected.-->
 		<token value="[O-]OC#N">peroxycyanate|peroxycyanat</token>
 		<token value="[Se-]C#N">selenocyanate|selenocyanat</token>
 		<token value="[Se-][N+]#[C-]">selenofulminate|selenofulminat</token>

--- a/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/functionalClasses.txt
+++ b/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/functionalClasses.txt
@@ -35,3 +35,7 @@ Butyltin chloride dihydroxide	InChI=1S/C4H9.ClH.2H2O.Sn/c1-3-4-2;;;;/h1,3-4H2,2H
 4-NITROBENZALDEHYDE S-(4-NITROPHENYL)THIOOXIME	InChI=1S/C13H9N3O4S/c17-15(18)11-3-1-10(2-4-11)9-14-21-13-7-5-12(6-8-13)16(19)20/h1-9H
 O-methyl phenylphosphonothioic chloride	InChI=1/C7H8ClOPS/c1-9-10(8,11)7-5-3-2-4-6-7/h2-6H,1H3
 O-(1-Methyl-2-methoxycarbonylvinyl) 4-Bromophenylthionophosphonic monochloride	InChI=1/C11H11BrClO3PS/c1-8(7-11(14)15-2)16-17(13,18)10-5-3-9(12)4-6-10/h3-7H,1-2H3
+phenyl peroxycyanate	InChI=1S/C7H5NO2/c8-6-9-10-7-4-2-1-3-5-7/h1-5H
+methyl peroxycyanate	InChI=1S/C2H3NO2/c1-4-5-2-3/h1H3
+peroxycyanic acid	InChI=1S/CHNO2/c2-1-4-3/h3H
+phenyl cyanate	InChI=1S/C7H5NO/c8-6-9-7-4-2-1-3-5-7/h1-5H


### PR DESCRIPTION
Fixes #306

Peroxycyanic acid is `N#C-O-OH`, so a phenyl ester is `N#C-O-O-C6H5`. OPSIN built it with three oxygens:

```
peroxycyanic acid     N#COO                  correct
phenyl peroxycyanate  C1(=CC=CC=C1)OOOC#N    an oxygen too many
methyl peroxycyanate  COOOC#N                an oxygen too many
```

### Cause

The acid and the ester reach the `peroxy` prefix by different routes.

The acid is `simpleGroups.xml` `cyanic`, `N#CO` with `functionalIDs="3"`, so `performPeroxyFunctionalReplacement` replaces that oxygen and the result is right.

The ester and salt use `functionalTerms.xml` `cyanate`, `[O-]C#N`. That is not an acid and offers nothing to replace, so `peroxy` falls through to its divalent joiner role in `multiRadicalSubstituents.xml` (`<token value="OO" outIDs="1,2" usableAsAJoiner="yes">`) and inserts `-O-O-` *alongside* cyanate's own oxygen.

### Fix

Give `peroxycyanate` its own token, as `hydroperoxide` (`[O-]O`) already sits next to `hydroxide` in the same list. The ester and salt then agree with the acid.

Peroxy esters of other acids were already correct and are untouched, since they replace a genuine hydroxyl. `phenyl peroxythiocyanate` was also already correct — thiocyanate's own atom is sulfur rather than the oxygen the peroxy contributes:

```
methyl peroxyacetate      C(C)(=O)OOC
tert-butyl peroxybenzoate C(C1=CC=CC=C1)(=O)OOC(C)(C)C
methyl peroxynitrate      [N+](=O)([O-])OOC
phenyl peroxythiocyanate  C1(=CC=CC=C1)OOSC#N
phenyl cyanate            C1(=CC=CC=C1)OC#N
```

Salts work too: `sodium peroxycyanate` → `[O-]OC#N.[Na+]`.

### Evidence

Of the 68 names in PubChem's `CID-IUPAC` dump that use this group, all 68 previously gave a silently wrong structure. 67 now give PubChem's exact StdInChIKey and none is wrong.

The remaining one, `(2-methylpropan-2-yl)oxy peroxycyanate`, is now rejected rather than wrong. That is a separate gap rather than a regression — stock OPSIN likewise rejects `(2-methylpropan-2-yl)oxy cyanate` and `(2-methylpropan-2-yl)oxy thiocyanate`, so an `-oxy` word esterifying one of these groups does not work in general.

### Testing

Full suite green, including `DtdTest`. A 500,000-name differential against 2.9.0 shows no name changing — peroxycyanate is absent from that sample, so the four cases added to `functionalClasses.txt` carry the regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
