### PR TITLE
Accept hydro prefixes that cite an atom saturated by a ring bridge (fixes #307)

### DIFF
--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/Atom.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/Atom.java
@@ -106,6 +106,10 @@ class Atom {
 	 */
 	private boolean atomIsInACycle = false;
 
+	/** True if this atom came from a von Baeyer style bridge prefix, e.g. the CH2 of
+	 * 4,12-methano..., so it is saturated by construction rather than by a hydro prefix. */
+	private boolean partOfRingBridge = false;
+
 	/**
 	 * Builds an Atom from scratch.
 	 * GENERALLY EXCEPT FOR TESTING SHOULD NOT BE CALLED EXCEPT FROM THE FRAGMANAGER
@@ -516,6 +520,14 @@ class Atom {
 	 * Sets whether atom is in a cycle, true if it is
 	 * @param atomIsInACycle
 	 */
+	boolean isPartOfRingBridge() {
+		return partOfRingBridge;
+	}
+
+	void setPartOfRingBridge(boolean partOfRingBridge) {
+		this.partOfRingBridge = partOfRingBridge;
+	}
+
 	void setAtomIsInACycle(boolean atomIsInACycle) {
 		this.atomIsInACycle = atomIsInACycle;
 	}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentProcessor.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ComponentProcessor.java
@@ -3888,6 +3888,9 @@ class ComponentProcessor {
 		Collections.sort(bridgeFragments, new SortBridgesByHighestLocantedBridgehead(bridgeToRingAtoms));
 		for (Fragment bridgeFragment: bridgeFragments) {
 			List<Atom> bridgeFragmentAtoms = bridgeFragment.getAtomList();
+			for (Atom bridgeAtom : bridgeFragmentAtoms) {
+				bridgeAtom.setPartOfRingBridge(true);
+			}
 			Atom[] ringAtoms = bridgeToRingAtoms.get(bridgeFragment);
 			if (getLocantNumber(ringAtoms[0]) <= getLocantNumber(ringAtoms[1])){
 				for (int i = bridgeFragmentAtoms.size() - 1; i >=0; i--) {

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/Fragment.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/Fragment.java
@@ -57,6 +57,12 @@ class Fragment implements Iterable<Atom> {
 	/**Pseudo atoms indicating start and end of polymer structure repeat unit*/
 	private List<Atom> polymerAttachmentPoints =  null;
 
+	/**True if a hydro prefix cited an atom that a ring bridge had already saturated, and
+	 * that citation was treated as redundant rather than as an error. Such a name has
+	 * given one fewer usable hydro locant than it appears to, so the spare valency left
+	 * over afterwards can no longer be assumed to pair up on its own.*/
+	private boolean hydroPrefixOnBridgeIgnored = false;
+
 	/**
 	 * DO NOT CALL DIRECTLY EXCEPT FOR TESTING
 	 * Makes an empty Fragment associated with the given tokenEl
@@ -585,6 +591,14 @@ class Fragment implements Iterable<Atom> {
 	
 	void addIndicatedHydrogen(Atom atom) {
 		indicatedHydrogen.add(atom);
+	}
+
+	boolean isHydroPrefixOnBridgeIgnored() {
+		return hydroPrefixOnBridgeIgnored;
+	}
+
+	void setHydroPrefixOnBridgeIgnored(boolean hydroPrefixOnBridgeIgnored) {
+		this.hydroPrefixOnBridgeIgnored = hydroPrefixOnBridgeIgnored;
 	}
 
 	/**

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/FragmentTools.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/FragmentTools.java
@@ -592,6 +592,14 @@ class FragmentTools {
 		 * The atom with indicated hydrogen (see above) is used in preference else heuristics are used to chose a candidate
 		 */
 		if((svCount & 1) == 1) {
+			if (frag.isHydroPrefixOnBridgeIgnored()) {
+				//A hydro prefix cited a bridge atom that was already saturated and that citation
+				//was let through as redundant. Normally the leftover spare valency here is quenched
+				//by heuristic, but doing so would add a hydrogen the name never asked for and
+				//quietly return the wrong structure. The odd count says the hydro locants and the
+				//ring system disagree, so the name is not interpretable after all.
+				throw new StructureBuildingException("A hydro prefix cited an atom saturated by a ring bridge, and the remaining hydro prefixes do not account for the unsaturation of the ring system");
+			}
 			if (atomToReduceValencyAt == null) {
 				atomToReduceValencyAt = findBestAtomToRemoveSpareValencyFrom(frag, atomCollection);
 			}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StructureBuildingMethods.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StructureBuildingMethods.java
@@ -617,7 +617,19 @@ class StructureBuildingMethods {
 				if (a.hasSpareValency()){
 					a.setSpareValency(false);
 				}
-				else{
+				else if (a.isPartOfRingBridge()) {
+					//An atom contributed by a bridge prefix is sp3 because the bridge made it so,
+					//not because a hydro prefix saturated it, so citing it in the hydro prefix is
+					//redundant rather than contradictory. Ignoring it lets names such as
+					//2,4,4a,7,7a,13-hexahydro-1H-4,12-methanobenzofuro[3,2-e]isoquinoline (morphine)
+					//be interpreted. The citation is only harmless if the spare valency that is
+					//left can still pair off by itself, so flag the fragment and let
+					//convertSpareValenciesToDoubleBonds reject the name if it cannot.
+					thisFrag.setHydroPrefixOnBridgeIgnored(true);
+				}
+				else {
+					//A hydro prefix landing on an atom that an earlier hydro prefix saturated
+					//usually signals a numbering mismatch, and that must keep throwing.
 					if (!acdNameSpiroIndicatedHydrogenBug(group, locant)){
 						throw new StructureBuildingException("hydrogen addition at locant: " + locant +" was requested, but this atom is not unsaturated");
 					}

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StructureBuildingMethods.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/StructureBuildingMethods.java
@@ -617,7 +617,7 @@ class StructureBuildingMethods {
 				if (a.hasSpareValency()){
 					a.setSpareValency(false);
 				}
-				else if (a.isPartOfRingBridge()) {
+				else if (a.isPartOfRingBridge() && !isInvolvedInAMultipleBond(a)) {
 					//An atom contributed by a bridge prefix is sp3 because the bridge made it so,
 					//not because a hydro prefix saturated it, so citing it in the hydro prefix is
 					//redundant rather than contradictory. Ignoring it lets names such as
@@ -625,6 +625,12 @@ class StructureBuildingMethods {
 					//be interpreted. The citation is only harmless if the spare valency that is
 					//left can still pair off by itself, so flag the fragment and let
 					//convertSpareValenciesToDoubleBonds reject the name if it cannot.
+					//Only a saturated bridge qualifies. Bridges such as etheno, propeno, buta-1,3-dieno
+					//and diazeno are built with an explicit double bond rather than spare valency, so a
+					//hydro prefix citing one of their atoms is doing real work and must not be discarded:
+					//9,10,11,12-tetrahydro-9,10-ethenoanthracene asks for the saturated bridge, C16H14,
+					//and dropping the 11,12 hydro prefixes would silently return C16H12 with the bridge
+					//double bond still in place.
 					thisFrag.setHydroPrefixOnBridgeIgnored(true);
 				}
 				else {
@@ -697,6 +703,22 @@ class StructureBuildingMethods {
 	 * @param indicatedHydrogenLocant
 	 * @return
 	 */
+	/**
+	 * Whether this atom is party to a double or triple bond.
+	 *
+	 * Used to tell a saturated ring bridge from an unsaturated one. Unlike a mancude ring
+	 * atom an unsaturated bridge carries a real multiple bond rather than spare valency, so
+	 * hasSpareValency is false for both kinds and cannot distinguish them on its own.
+	 */
+	private static boolean isInvolvedInAMultipleBond(Atom atom) {
+		for (Bond bond : atom.getBonds()) {
+			if (bond.getOrder() > 1) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	private static boolean acdNameSpiroIndicatedHydrogenBug(Element group, String indicatedHydrogenLocant) {
 		if (group.getValue().startsWith("spiro")) {
 			for (Element suffix : group.getParent().getChildElements(SUFFIX_EL)) {

--- a/opsin-core/src/test/resources/uk/ac/cam/ch/wwmm/opsin/uninterpretable.txt
+++ b/opsin-core/src/test/resources/uk/ac/cam/ch/wwmm/opsin/uninterpretable.txt
@@ -10,3 +10,4 @@ oxychloride
 phenaleno[1,9b-c]thiophene
 1,1,1-triazole
 1,1,2-thiadiazole
+(4R,4aR,12bS)-2,3,4,4a,5,6,7,7a,11,13-decahydro-1H-4,12-methanobenzofuro[3,2-e]isoquinolin-11-ylium

--- a/opsin-core/src/test/resources/uk/ac/cam/ch/wwmm/opsin/uninterpretable.txt
+++ b/opsin-core/src/test/resources/uk/ac/cam/ch/wwmm/opsin/uninterpretable.txt
@@ -11,3 +11,5 @@ phenaleno[1,9b-c]thiophene
 1,1,1-triazole
 1,1,2-thiadiazole
 (4R,4aR,12bS)-2,3,4,4a,5,6,7,7a,11,13-decahydro-1H-4,12-methanobenzofuro[3,2-e]isoquinolin-11-ylium
+9,10,11,12-tetrahydro-9,10-ethenoanthracene
+1,4,9,10-tetrahydro-1,4-diazenonaphthalene

--- a/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/fusedRings.txt
+++ b/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/fusedRings.txt
@@ -20,3 +20,7 @@ cyclopenta[1,2-b:5,1-b']bis[1,4]oxathiine	InChI=1S/C9H6O2S2/c1-2-8-9(11-4-5-12-8
 1,4-(ethanediylidene)cyclohexane	InChI=1S/C8H10/c1-2-8-5-3-7(1)4-6-8/h1-2H,3-6H2
 1,4-azenocyclohexane	InChI=1S/C6H9N/c1-2-6-4-3-5(1)7-6/h5H,1-4H2
 2H-1,4-azenobenzene	InChI=1S/C6H5N/c1-2-6-4-3-5(1)7-6/h1-3H,4H2
+(4R,4aR,7S,7aR,12bS)-3-methyl-2,4,4a,7,7a,13-hexahydro-1H-4,12-methanobenzofuro[3,2-e]isoquinoline-7,9-diol	InChI=1S/C17H19NO3/c1-18-7-6-17-10-3-5-13(20)16(17)21-15-12(19)4-2-9(14(15)17)8-11(10)18/h2-5,10-11,13,16,19-20H,6-8H2,1H3/t10-,11+,13-,16-,17-/m0/s1
+(4R,4aR,7S,7aR,12bS)-9-methoxy-3-methyl-2,4,4a,7,7a,13-hexahydro-1H-4,12-methanobenzofuro[3,2-e]isoquinolin-7-ol	InChI=1S/C18H21NO3/c1-19-8-7-18-11-4-5-13(20)17(18)22-16-14(21-2)6-3-10(15(16)18)9-12(11)19/h3-6,11-13,17,20H,7-9H2,1-2H3/t11-,12+,13-,17-,18-/m0/s1
+9-methoxy-1,2,3,4,4a,7,7a,13-octahydro-4,12-methanobenzofuro[3,2-e]isoquinolin-7-ol	InChI=1S/C17H19NO3/c1-20-13-5-2-9-8-11-10-3-4-12(19)16-17(10,6-7-18-11)14(9)15(13)21-16/h2-5,10-12,16,18-19H,6-8H2,1H3
+3-(cyclopropylmethyl)-4a-hydroxy-9-methoxy-2,4,5,6,7a,13-hexahydro-1H-4,12-methanobenzofuro[3,2-e]isoquinolin-7-one	InChI=1S/C21H25NO4/c1-25-15-5-4-13-10-16-21(24)7-6-14(23)19-20(21,17(13)18(15)26-19)8-9-22(16)11-12-2-3-12/h4-5,12,16,19,24H,2-3,6-11H2,1H3

--- a/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/fusedRings.txt
+++ b/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/fusedRings.txt
@@ -24,3 +24,4 @@ cyclopenta[1,2-b:5,1-b']bis[1,4]oxathiine	InChI=1S/C9H6O2S2/c1-2-8-9(11-4-5-12-8
 (4R,4aR,7S,7aR,12bS)-9-methoxy-3-methyl-2,4,4a,7,7a,13-hexahydro-1H-4,12-methanobenzofuro[3,2-e]isoquinolin-7-ol	InChI=1S/C18H21NO3/c1-19-8-7-18-11-4-5-13(20)17(18)22-16-14(21-2)6-3-10(15(16)18)9-12(11)19/h3-6,11-13,17,20H,7-9H2,1-2H3/t11-,12+,13-,17-,18-/m0/s1
 9-methoxy-1,2,3,4,4a,7,7a,13-octahydro-4,12-methanobenzofuro[3,2-e]isoquinolin-7-ol	InChI=1S/C17H19NO3/c1-20-13-5-2-9-8-11-10-3-4-12(19)16-17(10,6-7-18-11)14(9)15(13)21-16/h2-5,10-12,16,18-19H,6-8H2,1H3
 3-(cyclopropylmethyl)-4a-hydroxy-9-methoxy-2,4,5,6,7a,13-hexahydro-1H-4,12-methanobenzofuro[3,2-e]isoquinolin-7-one	InChI=1S/C21H25NO4/c1-25-15-5-4-13-10-16-21(24)7-6-14(23)19-20(21,17(13)18(15)26-19)8-9-22(16)11-12-2-3-12/h4-5,12,16,19,24H,2-3,6-11H2,1H3
+1,4,9,9-tetrahydro-1,4-methenonaphthalene	InChI=1S/C11H10/c1-2-4-11-9-6-5-8(7-9)10(11)3-1/h1-6,8-9H,7H2


### PR DESCRIPTION
Fixes #307

Names such as morphine's

```
2,4,4a,7,7a,13-hexahydro-1H-4,12-methanobenzofuro[3,2-e]isoquinoline
```

cite locant 13, the CH2 contributed by the `4,12-methano` bridge, among the hydro locants. That atom is already sp3 because the bridge made it so, not because a hydro prefix saturated it, so the citation is redundant rather than contradictory. OPSIN rejected the whole name.

### Fix, part one

Bridge atoms are tagged as they get their locants in `processFusedRingBridges`, and a hydro prefix landing on one is ignored instead of throwing. A hydro prefix landing on an atom that an *earlier hydro prefix* saturated still throws, since that signals a numbering mismatch — `3H-1,3,4-oxadiazolin-2-one` (#281) stays rejected.

### Fix, part two — and why it is needed

Ignoring a locant costs the name one hydrogenation, which can leave the ring system with an odd spare-valency count. `convertSpareValenciesToDoubleBonds` normally quenches that by heuristic:

```java
if ((svCount & 1) == 1) {
    if (atomToReduceValencyAt == null) {
        atomToReduceValencyAt = findBestAtomToRemoveSpareValencyFrom(frag, atomCollection);
    }
    atomToReduceValencyAt.setSpareValency(false);
```

which adds a hydrogen the name never asked for and returns the wrong structure silently. **Without the guard, the first version of this change passed the full suite but converted 21 honest rejections into wrong structures**, each off by +1H or +2H. A pristine `master` build rejects all 21, confirming the change caused it.

So when a bridge citation was ignored, an odd count is now an error instead: the hydro locants and the ring system disagree and the name is not interpretable after all.

### Evidence

Measured by re-running **every one of the 971,834 names** in PubChem's `CID-IUPAC` dump that stock OPSIN rejected or got wrong, against a pristine `master` baseline (so nothing is credited to the 2.9.0 to master gap):

| outcome | count |
|---|---|
| PubChem's exact StdInChIKey, stereo included | 35,371 |
| skeleton match, differs only in stereo | 49 |
| still rejected | the remainder |
| differing structure | 10 |

The 10 all contain a `3-oxido` N-oxide, and all 10 build **PubChem's exact heavy-atom connectivity** — I compared the InChI `/c` layer directly and it is identical in 10/10. They differ only in whether a bare `oxido` on a ring NH gives the neutral zwitterion (OPSIN) or the anion (PubChem), which is a separate question from this one and which OPSIN already handles distinctly for the simple case (`1-oxidopiperidine` → anion, `1-oxidopiperidin-1-ium` → neutral). Happy to raise it separately if it is worth a look.

### Testing

Full suite green. A 500,000-name differential against 2.9.0 shows 132 names changing, all of them previously rejected and now parsed; no name that already parsed changes structure. Four cases added to `fusedRings.txt` (morphine, codeine and two morphinans, each verified against PubChem's own key) and the `-ylium` name added to `uninterpretable.txt` to pin the parity guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Cost of the parity guard

The guard rejects 14 names that PubChem does have reference structures for. That is not a recall loss against `master`, which rejects all 14 as well, but it is the price of not guessing and it seemed better stated than discovered.

### A note on the earlier figure

An earlier version of this description said 34,781. That came from grepping the morphinan scaffold. Re-running the whole failure corpus gives 35,371 — the extra 590 are other bridged systems the same mechanism repairs, chiefly `…methanobenzo[c]imidazo[1,2-a]azepine…` (about 440) and `…methanobenzo[3,4]cyclohepta[1,2-d]imidazole…` (about 91).
