### PR TITLE
Accept locant 8 for the pyrrolizine ring-fusion carbon (fixes #315)

### DIFF
--- a/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/arylGroups.xml
+++ b/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/arylGroups.xml
@@ -280,7 +280,7 @@
 		<token value="c1(O)c(O)c(O)ccc1" labels="1//2,ortho//3,meta//4,para/5/6">pyrogallol</token>
 		<token value="[nH]1cccc1" labels="1/2/3/4/5">pyrrol</token>
 		<token value="C1CCN2CCCC12" labels="1/2/3/4/5/6/7/7a">pyrrolizidin</token>
-		<token value="[cH2]1ccn2cccc12" labels="1/2/3/4/5/6/7/7a">pyrrolizin</token>
+		<token value="[cH2]1ccn2cccc12" labels="1/2/3/4/5/6/7/7a,8">pyrrolizin</token>
 		<token value="N1CCCC1" labels="1/2/3/4/5">pyrrolidin</token>
 		<token value="N1CCCC1" labels="1/2/3/4/5" addGroup="=O locant 2" frontLocantsExpected="2,3,4,5">pyrrolidon</token>
 		<token value="N1CCCC1" labels="1/2/3/4/5" addBond="2 defaultLocant 2" frontLocantsExpected="1,2,3,4,5">pyrrolin</token>

--- a/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/fusionComponents.xml
+++ b/opsin-core/src/main/resources/uk/ac/cam/ch/wwmm/opsin/resources/fusionComponents.xml
@@ -125,7 +125,7 @@
 		<token value="n1ccccc1" labels="1/2/3/4/5/6">pyridino|pyrido</token>
 		<token value="n1cnccc1" labels="1/2/3/4/5/6">pyrimidino|pyrimido</token>
 		<token value="C1CCN2CCCC12" labels="1/2/3/4/5/6/7/7a">pyrrolizidino</token>
-		<token value="[cH2]1ccn2cccc12" labels="1/2/3/4/5/6/7/7a">pyrrolizino</token>
+		<token value="[cH2]1ccn2cccc12" labels="1/2/3/4/5/6/7/7a,8">pyrrolizino</token>
 		<token value="[nH]1cccc1" labels="1/2/3/4/5">pyrrolo</token>
 		<token value="n1cncc2ccccc12" labels="1/2/3/4/4a/5/6/7/8/8a">quinazolino</token>
 		<token value="c1cccc2nc3c4ccccc4nc3cc12" labels="1/2/3/4/4a/5/5a/5b/6/7/8/9/9a/10/10a/11/11a">quindolino</token>

--- a/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/fusedRings.txt
+++ b/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/fusedRings.txt
@@ -20,3 +20,5 @@ cyclopenta[1,2-b:5,1-b']bis[1,4]oxathiine	InChI=1S/C9H6O2S2/c1-2-8-9(11-4-5-12-8
 1,4-(ethanediylidene)cyclohexane	InChI=1S/C8H10/c1-2-8-5-3-7(1)4-6-8/h1-2H,3-6H2
 1,4-azenocyclohexane	InChI=1S/C6H9N/c1-2-6-4-3-5(1)7-6/h5H,1-4H2
 2H-1,4-azenobenzene	InChI=1S/C6H5N/c1-2-6-4-3-5(1)7-6/h1-3H,4H2
+2-(1,2,3,5,6,7-hexahydropyrrolizin-8-ylmethoxy)pyrido[4,3-d]pyrimidine	InChI=1S/C15H18N4O/c1-4-15(5-2-8-19(15)7-1)11-20-14-17-10-12-9-16-6-3-13(12)18-14/h3,6,9-10H,1-2,4-5,7-8,11H2
+2-(1,2,3,5,6,7-hexahydropyrrolizin-7a-ylmethoxy)pyrido[4,3-d]pyrimidine	InChI=1S/C15H18N4O/c1-4-15(5-2-8-19(15)7-1)11-20-14-17-10-12-9-16-6-3-13(12)18-14/h3,6,9-10H,1-2,4-5,7-8,11H2


### PR DESCRIPTION
Fixes #315

`arylGroups.xml:283` labels the pyrrolizine ring-fusion carbon only `7a`, so every name using the pyrrolizidine-alkaloid convention of `8` is rejected with `Could not find the atom with locant 8`.

```
2-(1,2,3,5,6,7-hexahydropyrrolizin-8-ylmethoxy)pyrido[4,3-d]pyrimidine    rejected
2-(1,2,3,5,6,7-hexahydropyrrolizin-7a-ylmethoxy)pyrido[4,3-d]pyrimidine   parses
```

`8` is otherwise unused for this ring, so the alias is unambiguous, and the label syntax already supports alternatives per atom the way benzene's `2,ortho` does. The change is one character in each of `arylGroups.xml` (`pyrrolizin`) and `fusionComponents.xml` (`pyrrolizino`).

### Evidence

Re-running the 971,834 names in `CID-IUPAC` that stock OPSIN rejected or got wrong, against a pristine `master` baseline:

| | |
|---|---|
| names mentioning pyrrolizine that stock cannot parse | 98,688 |
| now give PubChem's exact StdInChIKey | **94,456 (95.7%)** |
| names that previously passed and now change | **0** |

### The two things worth checking in review

**The 500,000-name differential reports one changed structure, and it is a correction rather than a regression.** `8-hydroxy-N,N-dimethyl-6-(2-methyl-1,2,4a,5,6,7,8,8a-octahydronaphthalene-1-carbonyl)-5-oxo-2,3-dihydro-1H-pyrrolizine-1-carboxamide` (CID 20768037) now gives `KXJWHDKJOPCFAI-UHFFFAOYSA-N`, which is PubChem's own key. Previously the `8-hydroxy` was being placed on the octahydronaphthalene substituent instead of the pyrrolizine parent.

**57 names go from rejected to a structure that disagrees with PubChem.** These are not caused by this change: rewriting `8` to `7a` by hand and running them on `master` gives byte-identical output. For example `2-[(2S,8R)-2,3,5,6,7,8-hexahydro-1H-pyrrolizin-2-yl]-4H-indeno[1,2-d][1,3]thiazole` and its `7a` spelling both give `OAGPLVKQALIKCL-QWHCGFSZSA-N`. The disagreement is in the `indeno[1,2-d][1,3]thiazole` component, which this change simply lets the parser reach.

### Testing

Suite 682 + 1059, green. 500,000-name differential: 92 newly parsed, 0 newly rejected, 1 changed structure (the correction above). Two cases added to `fusedRings.txt`, the `8` and `7a` spellings of the same compound, so the alias is pinned to give one structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
