### PR TITLE
Reject chalcogens/halogens made hypervalent by an invented hydrogen (fixes #323)

### DIFF
--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ValencyChecker.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ValencyChecker.java
@@ -335,7 +335,56 @@ class ValencyChecker {
 		if(maxVal == null) {
 			return true;
 		}
-		return valency <= maxVal;
+		if (valency > maxVal) {
+			return false;
+		}
+		return valencyIsAttainable(a, valency);
+	}
+
+	/**
+	 * Chalcogens and halogens have a discontinuous set of stable valencies when uncharged e.g. 2, 4 and 6 for sulfur.
+	 * Only the lowest of these is reachable by adding implicit hydrogen; a hypervalent chalcogen or halogen is
+	 * always made hypervalent by bonds to other elements, never by a hydrogen, so the higher valencies must be
+	 * reached by the bonds the name actually specifies.
+	 * Hence 1-methylthiophene is not sulfur in a 4 valent state with an invented hydrogen, it is a name that
+	 * would have had to say 1-methylthiophen-1-ium (or use the lambda convention) to mean anything; the oxygen
+	 * analogue, 1-methylfuran, is already rejected only because oxygen happens to have a single stable valency.
+	 * The valency that implicit hydrogen may bring the atom up to is the standard bonding number of the element
+	 * (adjusted by explicitly added/removed protons), matching how {@link Atom#determineValency(boolean)} decides
+	 * the number of hydrogens to add.
+	 * Group 15 is deliberately not included: R2P(=O)H and its relatives are conventional, so phosphorus does
+	 * reach a hypervalent state with an implicit hydrogen e.g. 2-oxo-1,3-dihydroisophosphindole.
+	 * Charged atoms, lambda convention atoms and atoms whose valency was set explicitly (e.g. by a SMILES in
+	 * the dictionary) state their valency rather than having it inferred, so are not subject to this check.
+	 * @param a
+	 * @param valency
+	 * @return
+	 */
+	private static boolean valencyIsAttainable(Atom a, int valency) {
+		if (a.getCharge() != 0 || a.getLambdaConventionValency() != null || a.getMinimumValency() != null) {
+			return true;
+		}
+		ChemEl chemEl = a.getElement();
+		if (!chemEl.isChalcogen() && !chemEl.isHalogen()) {
+			return true;
+		}
+		Integer defaultValency = getDefaultValency(chemEl);
+		if (defaultValency == null) {
+			return true;
+		}
+		if (valency <= defaultValency + a.getProtonsExplicitlyAddedOrRemoved()) {
+			return true;
+		}
+		Integer[] possibleValencies = getPossibleValencies(chemEl, 0);
+		if (possibleValencies == null) {
+			return true;
+		}
+		for (Integer possibleValency : possibleValencies) {
+			if (possibleValency == valency) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/** Check whether valency is available on the atom to form a bond of the given order.

--- a/opsin-core/src/test/resources/uk/ac/cam/ch/wwmm/opsin/uninterpretable.txt
+++ b/opsin-core/src/test/resources/uk/ac/cam/ch/wwmm/opsin/uninterpretable.txt
@@ -10,3 +10,5 @@ oxychloride
 phenaleno[1,9b-c]thiophene
 1,1,1-triazole
 1,1,2-thiadiazole
+1-methylthiophene
+1-methylselenophene

--- a/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/functionalClasses.txt
+++ b/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/functionalClasses.txt
@@ -35,3 +35,6 @@ Butyltin chloride dihydroxide	InChI=1S/C4H9.ClH.2H2O.Sn/c1-3-4-2;;;;/h1,3-4H2,2H
 4-NITROBENZALDEHYDE S-(4-NITROPHENYL)THIOOXIME	InChI=1S/C13H9N3O4S/c17-15(18)11-3-1-10(2-4-11)9-14-21-13-7-5-12(6-8-13)16(19)20/h1-9H
 O-methyl phenylphosphonothioic chloride	InChI=1/C7H8ClOPS/c1-9-10(8,11)7-5-3-2-4-6-7/h2-6H,1H3
 O-(1-Methyl-2-methoxycarbonylvinyl) 4-Bromophenylthionophosphonic monochloride	InChI=1/C11H11BrClO3PS/c1-8(7-11(14)15-2)16-17(13,18)10-5-3-9(12)4-6-10/h3-7H,1-2H3
+dimethyl sulfoxide	InChI=1/C2H6OS/c1-4(2)3/h1-2H3
+dimethyl sulfone	InChI=1/C2H6O2S/c1-5(2,3)4/h1-2H3
+thiophene 1,1-dioxide	InChI=1/C4H4O2S/c5-7(6)3-1-2-4-7/h1-4H

--- a/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/ions.txt
+++ b/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/ions.txt
@@ -10,3 +10,4 @@ methylphosphonoylium	InChI=1/CH3OP/c1-3-2/h1H3/q+2
 glutarylium	InChI=1/C5H6O2/c6-4-2-1-3-5-7/h1-3H2/q+2
 pentanedioylium	InChI=1/C5H6O2/c6-4-2-1-3-5-7/h1-3H2/q+2
 pyridine-2,6-dicarbonylium	InChI=1/C7H3NO2/c9-4-6-2-1-3-7(5-10)8-6/h1-3H/q+2
+1-methylthiophen-1-ium	InChI=1/C5H7S/c1-6-4-2-3-5-6/h2-5H,1H3/q+1

--- a/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/miscellany.txt
+++ b/opsin-inchi/src/test/resources/uk/ac/cam/ch/wwmm/opsin/miscellany.txt
@@ -76,3 +76,7 @@ lithium triethylborodeuteride	InChI=1S/C6H16B.Li/c1-4-7(5-2)6-3;/h7H,4-6H2,1-3H3
 (cycloprop-2-en-1-ylidenethenylidene)cyclohexane	InChI=1S/C11H12/c1-2-4-10(5-3-1)6-7-11-8-9-11/h8-9H,1-5H2
 4-(4-fluoro-o-tolyl)-morpholine	InChI=1S/C11H14FNO/c1-9-8-10(12)2-3-11(9)13-4-6-14-7-5-13/h2-3,8H,4-7H2,1H3
 (S)-6-methylnicotine	InChI=1S/C11H16N2/c1-9-5-6-10(8-12-9)11-4-3-7-13(11)2/h5-6,8,11H,3-4,7H2,1-2H3/t11-/m0/s1
+thiophene	InChI=1/C4H4S/c1-2-4-5-3-1/h1-4H
+tetrahydrothiophene	InChI=1/C4H8S/c1-2-4-5-3-1/h1-4H2
+methylsulfanylbenzene	InChI=1/C7H8S/c1-8-7-5-3-2-4-6-7/h2-6H,1H3
+methanesulfonic acid	InChI=1/CH4O3S/c1-5(2,3)4/h1H3,(H,2,3,4)/f/h2H


### PR DESCRIPTION
Fixes #323

```
1-methylthiophene        CS1C=CC=C1       accepted, no warning -- neutral S with three bonds
1-methylfuran            rejected         "Element: O valency: 3"
1-methylthiophen-1-ium   C[S+]1C=CC=C1    the structure that name denotes
1-methylselenophene      C[SeH]1C=CC=C1   accepted, with an invented hydrogen
```

`getMaximumValency` returns only the last entry of `possibleStableValencies` and `checkValency` tests only `valency <= maximum`, so neutral S `{2,4,6}` passes at valency 3 while neutral O `{2}` fails. Every element with a discontinuous set is unchecked at its intermediate valencies.

### Please read this part before the numbers

**Unlike the other PRs I have sent, this one is a recall loss.** It converts silently wrong structures into rejections. That is an improvement in kind, but it will make some names stop working, and that is your call to weigh rather than mine to slip past you.

### Fix

A new `valencyIsAttainable` in `checkValency` only. `getMaximumValency` is untouched — `FragmentTools`, `StructureBuilder` and `StructureBuildingMethods` all want the maximum and would be broken by changing its contract.

The rule: implicit hydrogen may bring an atom up to its standard bonding number, but must not push it into a hypervalent state, because **a hypervalent chalcogen or halogen is made hypervalent by bonds to other elements, never by a hydrogen**. Exempt are charged atoms, lambda-convention atoms, and atoms with an explicitly set valency — all of these state their valency rather than infer it.

`checkValencyAvailableForBond` and `checkValencyAvailableForReplacementByHeteroatom` are deliberately unchanged; they are asked mid-construction whether one more bond fits, and tightening them breaks sulfone and sulfonic acid assembly.

**Two things that do not work, recorded so they are not retried:**

- **Exact set membership.** Valency at check time counts bonds to heavy atoms only, and `Atom.determineValency` fills the shortfall with implicit hydrogen, so exact membership rejects `methylphosphane` (P valency 1, not in `{3,5}`).
- **Applying the rule to every element with a standard bonding number.** Chemically wrong for group 15: `R2P(=O)H` is conventional, and this rejected `2-oxo-1,3-dihydroisophosphindole`, which master gets exactly right. Restricting to chalcogens and halogens removed that regression at a cost of 8 of 282 detections.

### Evidence

Over the 971,834 names in `CID-IUPAC` that stock rejected or got wrong, against a pristine `master` baseline:

| | |
|---|---|
| silently wrong structures now honestly rejected | **12,315** |
| names that were CORRECT and are now rejected | **0** |
| structures changed anywhere in the corpus | **0** |

The only transition that occurs at all is `MISMATCH -> RECALL_FAIL`. Nothing else moves.

Every newly rejected name was adjudicated against PubChem's own key rather than sampled, across three differentials totalling 1.4M names — a general 500,000; a 500,000 enriched for at-risk element tokens; and a 400,000 restricted to lambda-convention names, which is the corpus where an intermediate valency is legitimate and therefore the sharpest test of narrowness:

```
general 500k    differing 87   newlyParsed 0  newlyRejected 87   changedStructure 0
element-token   differing 143  newlyParsed 0  newlyRejected 143  changedStructure 0
lambda 400k     differing 47   newlyParsed 0  newlyRejected 47   changedStructure 0
```

**274 unique newly rejected names, master wrong on all 274, correct on none.**

Radicals were checked separately with `-r`: `sulfanyl`, `methylsulfanyl`, `sulfanylidene`, `sulfanediyl`, `methanesulfinyl`, `methanesulfonyl`, `phosphanyl` and `thiophen-2-yl` are unchanged. Only `sulfanetriyl`, `sulfanylidyne`, `thiophen-1-yl` and `selenophen-1-yl` flip to rejected, each a case of master inventing an S-H on a lambda4 sulfur.

### Testing

Suite 684 + 1065, green (master is 682 + 1057; the difference is exactly the 2 + 8 tests added). The new tests were confirmed to **bite**: copied onto pristine master they fail with `1-methylthiophene should be uninterpretable ==> expected: <FAILURE> but was: <SUCCESS>`, while all 8 controls pass on master too, which is what a control should do. Expected InChIs were verified against RDKit independently of OPSIN.

Controls added across `functionalClasses.txt`, `ions.txt` and `miscellany.txt`: `dimethyl sulfoxide`, `dimethyl sulfone`, `thiophene 1,1-dioxide`, `1-methylthiophen-1-ium`, `thiophene`, `tetrahydrothiophene`, `methylsulfanylbenzene`, `methanesulfonic acid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
