### PR TITLE
Walk only the live DFA transitions when parsing

### DIFF
--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ParseRules.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ParseRules.java
@@ -105,7 +105,6 @@ public class ParseRules {
 		int posInNameOfLastSuccessfulAnnotations = 0;
 		List<AnnotatorState> successfulAnnotations = new ArrayList<>();
 		AnnotatorState longestAnnotation = initialState;//this is the longest annotation. It does not necessarily end in an accept state
-		int stateSymbolsSize = stateSymbols.length;
 		while (!asStack.isEmpty()) {
 			AnnotatorState as = asStack.removeLast();//depth-first avoids pathological memory consumption if parsing ambiguity is encountered
 			int posInName = as.getPosInName();

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ParseRules.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ParseRules.java
@@ -37,6 +37,13 @@ public class ParseRules {
 	
 	private final AnnotatorState initialState;
 
+	/* Sparse (CSR) copy of chemAutomaton's transition table, restricted to the
+	 * stateSymbols alphabet. transitionRowStart[s]..transitionRowStart[s+1] indexes
+	 * transitionSymbolIndex/transitionNextState for the live transitions of state s. */
+	private final int[] transitionRowStart;
+	private final int[] transitionSymbolIndex;
+	private final int[] transitionNextState;
+
 	/**
 	 * Creates a left to right parser that can parse a substituent/full/functional word
 	 * @param resourceManager
@@ -48,6 +55,36 @@ public class ParseRules {
 		this.symbolRegexesDict = resourceManager.getSymbolRegexesDict();
 		this.stateSymbols = chemAutomaton.getCharIntervals();
 		this.initialState = new AnnotatorState(chemAutomaton.getInitialState(), '\0', 0, true, null);
+
+		int nStates = chemAutomaton.getSize();
+		int nSymbols = stateSymbols.length;
+		int[] rowStart = new int[nStates + 1];
+		int live = 0;
+		for (int s = 0; s < nStates; s++) {
+			rowStart[s] = live;
+			for (int i = 0; i < nSymbols; i++) {
+				if (chemAutomaton.step(s, stateSymbols[i]) != -1) {
+					live++;
+				}
+			}
+		}
+		rowStart[nStates] = live;
+		int[] symIdx = new int[live];
+		int[] nextSt = new int[live];
+		int p = 0;
+		for (int s = 0; s < nStates; s++) {
+			for (int i = 0; i < nSymbols; i++) {
+				int ns = chemAutomaton.step(s, stateSymbols[i]);
+				if (ns != -1) {
+					symIdx[p] = i;
+					nextSt[p] = ns;
+					p++;
+				}
+			}
+		}
+		this.transitionRowStart = rowStart;
+		this.transitionSymbolIndex = symIdx;
+		this.transitionNextState = nextSt;
 	}
 
 	/**Determines the possible annotations for a chemical word
@@ -89,10 +126,13 @@ public class ParseRules {
 				longestAnnotation = as;
 			}
 
-			for (int i = 0; i < stateSymbolsSize; i++) {
+			int currentState = as.getState();
+			int rowEnd = transitionRowStart[currentState + 1];
+			for (int r = transitionRowStart[currentState]; r < rowEnd; r++) {
+				int i = transitionSymbolIndex[r];
 				char annotationCharacter = stateSymbols[i];
-				int potentialNextState = chemAutomaton.step(as.getState(), annotationCharacter);
-				if (potentialNextState != -1) {//-1 means this state is not accessible from the previous state
+				int potentialNextState = transitionNextState[r];
+				{
 					OpsinRadixTrie possibleTokenisationsTrie = symbolTokenNamesDict[i];
 					if (possibleTokenisationsTrie != null) {
 						List<Integer> possibleTokenisations = possibleTokenisationsTrie.findMatches(chemicalWordLowerCase, posInName);

--- a/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ParseRules.java
+++ b/opsin-core/src/main/java/uk/ac/cam/ch/wwmm/opsin/ParseRules.java
@@ -126,44 +126,41 @@ public class ParseRules {
 			}
 
 			int currentState = as.getState();
-			int rowEnd = transitionRowStart[currentState + 1];
-			for (int r = transitionRowStart[currentState]; r < rowEnd; r++) {
+			for (int r = transitionRowStart[currentState], rowEnd = transitionRowStart[currentState + 1]; r < rowEnd; r++) {
 				int i = transitionSymbolIndex[r];
 				char annotationCharacter = stateSymbols[i];
 				int potentialNextState = transitionNextState[r];
-				{
-					OpsinRadixTrie possibleTokenisationsTrie = symbolTokenNamesDict[i];
-					if (possibleTokenisationsTrie != null) {
-						List<Integer> possibleTokenisations = possibleTokenisationsTrie.findMatches(chemicalWordLowerCase, posInName);
-						if (possibleTokenisations != null) {//next could be a token
-							for (int j = 0, l = possibleTokenisations.size(); j < l; j++) {//typically list size will be 1 so this is faster than an iterator
-								int tokenizationIndex = possibleTokenisations.get(j);
-								AnnotatorState newAs = new AnnotatorState(potentialNextState, annotationCharacter, tokenizationIndex, false, as);
-								//System.out.println("tokened " + chemicalWordLowerCase.substring(posInName, tokenizationIndex));
-								asStack.add(newAs);
-							}
-						}
-					}
-					RunAutomaton possibleAutomata = symbolRegexAutomataDict[i];
-					if (possibleAutomata != null) {//next could be an automaton
-						int matchLength = possibleAutomata.run(chemicalWord, posInName);
-						if (matchLength != -1){//matchLength = -1 means it did not match
-							int tokenizationIndex = posInName + matchLength;
-							AnnotatorState newAs = new AnnotatorState(potentialNextState, annotationCharacter, tokenizationIndex, true, as);
-							//System.out.println("neword automata " + chemicalWord.substring(posInName, tokenizationIndex));
+				OpsinRadixTrie possibleTokenisationsTrie = symbolTokenNamesDict[i];
+				if (possibleTokenisationsTrie != null) {
+					List<Integer> possibleTokenisations = possibleTokenisationsTrie.findMatches(chemicalWordLowerCase, posInName);
+					if (possibleTokenisations != null) {//next could be a token
+						for (int j = 0, l = possibleTokenisations.size(); j < l; j++) {//typically list size will be 1 so this is faster than an iterator
+							int tokenizationIndex = possibleTokenisations.get(j);
+							AnnotatorState newAs = new AnnotatorState(potentialNextState, annotationCharacter, tokenizationIndex, false, as);
+							//System.out.println("tokened " + chemicalWordLowerCase.substring(posInName, tokenizationIndex));
 							asStack.add(newAs);
 						}
 					}
-					Pattern possibleRegex = symbolRegexesDict[i];
-					if (possibleRegex != null) {//next could be a regex
-						Matcher mat = possibleRegex.matcher(chemicalWord).region(posInName, chemicalWord.length());
-						mat.useTransparentBounds(true);
-						if (mat.lookingAt()) {//match at start
-							int tokenizationIndex = posInName + mat.group(0).length();
-							AnnotatorState newAs = new AnnotatorState(potentialNextState, annotationCharacter, tokenizationIndex, true, as);
-							//System.out.println("neword regex " + mat.group(0));
-							asStack.add(newAs);
-						}
+				}
+				RunAutomaton possibleAutomata = symbolRegexAutomataDict[i];
+				if (possibleAutomata != null) {//next could be an automaton
+					int matchLength = possibleAutomata.run(chemicalWord, posInName);
+					if (matchLength != -1){//matchLength = -1 means it did not match
+						int tokenizationIndex = posInName + matchLength;
+						AnnotatorState newAs = new AnnotatorState(potentialNextState, annotationCharacter, tokenizationIndex, true, as);
+						//System.out.println("neword automata " + chemicalWord.substring(posInName, tokenizationIndex));
+						asStack.add(newAs);
+					}
+				}
+				Pattern possibleRegex = symbolRegexesDict[i];
+				if (possibleRegex != null) {//next could be a regex
+					Matcher mat = possibleRegex.matcher(chemicalWord).region(posInName, chemicalWord.length());
+					mat.useTransparentBounds(true);
+					if (mat.lookingAt()) {//match at start
+						int tokenizationIndex = posInName + mat.group(0).length();
+						AnnotatorState newAs = new AnnotatorState(potentialNextState, annotationCharacter, tokenizationIndex, true, as);
+						//System.out.println("neword regex " + mat.group(0));
+						asStack.add(newAs);
 					}
 				}
 			}


### PR DESCRIPTION
Parsing spends about a third of its time asking the automaton about transitions that do not exist. This walks only the ones that do. No behaviour changes.

### Where the time goes

Profiling stock 2.9.0 with JFR over 200,000 PubChem names puts ~34% of all execution samples inside the `dk.brics.automaton` transition lookup, essentially all of it reached from the inner loop of `getParses`:

```java
for (int i = 0; i < stateSymbolsSize; i++) {
    char annotationCharacter = stateSymbols[i];
    int potentialNextState = chemAutomaton.step(as.getState(), annotationCharacter);
    if (potentialNextState != -1) {//-1 means this state is not accessible from the previous state
```

That asks for a transition on every one of the 160 grammar symbols, for every parser state visited. The table is only **6.87% dense** — 253,275 live transitions out of 23,050 × 160, a mean of 11 per state and a median of 6. Roughly 93% of the `step()` calls exist only to be told −1.

### The change

`ParseRules` builds a CSR (sparse row) copy of the automaton's transition table once, at construction, restricted to the `stateSymbols` alphabet:

```java
private final int[] transitionRowStart;
private final int[] transitionSymbolIndex;
private final int[] transitionNextState;
```

The inner loop then iterates that state's live transitions directly, so the `-1` check disappears along with the dead probes:

```java
int currentState = as.getState();
int rowEnd = transitionRowStart[currentState + 1];
for (int r = transitionRowStart[currentState]; r < rowEnd; r++) {
    int i = transitionSymbolIndex[r];
    char annotationCharacter = stateSymbols[i];
    int potentialNextState = transitionNextState[r];
```

Same symbols, same order, same states — only the ones that would have returned −1 are skipped. Construction cost is three int arrays totalling ~530k entries, built once per `ParseRules`.

One file, +43/−3, no API or resource changes.

### Evidence

**Output is unchanged.** Over the 971,836 PubChem names in my audit corpus that stock OPSIN fails to interpret — the population most likely to expose a parser difference — SMILES output is **byte-identical** to a pristine `master` build. The 500,000-name differential I use as a regression gate is also byte-identical to the 2.9.0 baseline: **0 differing rows**.

**Suite is green**: 682 core + 1057 integration, no failures.

**Speed**, same corpus of 971,836 names, single-threaded, two reps each on an M-series laptop:

| build | rep 1 | rep 2 | mean |
|---|---|---|---|
| `master` | 339s | 336s | 337.5s |
| this branch | 263s | 265s | 264.0s |

**1.28× / 21.8% faster** end-to-end, deterministic across reps. The gain is larger on names that parse quickly and are dominated by automaton walking; long, deeply nested names spend proportionally more time elsewhere.

This is independent of #303 (`ParseRules` vs `Cli`); the two compose.
