### PR TITLE
Upgrade log4j-api/log4j-core to 2.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,12 +218,12 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.25.3</version>
+        <version>2.25.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.25.3</version>
+        <version>2.25.5</version>
       </dependency>
       <dependency>
         <groupId>io.github.dan2097</groupId>


### PR DESCRIPTION
Fixes GHSA-qv9r-c865-cp47 (CVE affecting log4j-api 2.25.3).